### PR TITLE
Removed dead AB links, updated credits and wiki links

### DIFF
--- a/Commands/PM/help.js
+++ b/Commands/PM/help.js
@@ -2,5 +2,5 @@ module.exports = (bot, db, config, winston, userDocument, msg) => {
 	const info = bot.getPMCommandList().map(command => {
 		return `${command} ${bot.getPMCommandMetadata(command).usage}`;
 	}).sort();
-	msg.channel.createMessage(`You can use these commands in PM with me: 🍪\`\`\`${info.join("\n")}\`\`\`Learn more at <https://awesomebot.xyz/wiki> 📘`);
+	msg.channel.createMessage(`You can use these commands in PM with me: 🍪\`\`\`${info.join("\n")}\`\`\`Learn more at <${config.hosting_url}wiki> 📘`);
 };

--- a/Commands/PM/help.js
+++ b/Commands/PM/help.js
@@ -2,5 +2,5 @@ module.exports = (bot, db, config, winston, userDocument, msg) => {
 	const info = bot.getPMCommandList().map(command => {
 		return `${command} ${bot.getPMCommandMetadata(command).usage}`;
 	}).sort();
-	msg.channel.createMessage(`You can use these commands in PM with me: 🍪\`\`\`${info.join("\n")}\`\`\`Learn more at <${config.hosting_url}wiki> 📘`);
+	msg.channel.createMessage(`You can use these commands in PM with me: 🍪\`\`\`${info.join("\n")}\`\`\`Learn more at <https://awesomebot.xyz/wiki> 📘`);
 };

--- a/Commands/Public/about.js
+++ b/Commands/Public/about.js
@@ -1,7 +1,7 @@
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix) => {
 	if(suffix && ["bug", "suggestion", "feature", "issue"].indexOf(suffix.toLowerCase())>-1) {
-		msg.channel.createMessage(`🐜 Please file your ${suffix.toLowerCase()} here: https://github.com/BitQuote/AwesomeBot/issues/new`);
+		msg.channel.createMessage(`🐜 Please file your ${suffix.toLowerCase()} here: https://github.com/GilbertGobbels/GAwesomeBot/issues/new`);
 	} else {
-		msg.channel.createMessage(`Hello! I'm AwesomeBot, the best discord bot! 🐬 Use \`${bot.getCommandPrefix(msg.guild, serverDocument)}help\` to list commands. Created by BitQuote. Built on NodeJS with Eris. Go to <https://awesomebot.xyz/> to learn more, or join our Discord server: <${config.discord_link}>`);
+		msg.channel.createMessage(`Hello! I'm GAwesomeBot, the best discord bot! 🐬 Use \`${bot.getCommandPrefix(msg.guild, serverDocument)}help\` to list commands. Developed by Gilbert, based off AB by BitQuote. Built on NodeJS with Eris. Go to <https://bot.gilbertgobbels.xyz:8008/> to learn more, or join our Discord server: <${config.discord_link}>`);
 	}
 };

--- a/Commands/Public/help.js
+++ b/Commands/Public/help.js
@@ -1,7 +1,7 @@
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix) => {
 	if(suffix) {
 		const getCommandHelp = (name, type, usage, description) => {
-			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<${config.hosting_url}wiki/Commands#${name}>`;
+			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<https://awesomebot.xyz/wiki/Commands#${name}>`;
 		};
 
 		const info = [];
@@ -35,7 +35,7 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		Object.keys(commands).sort().forEach(category => {
 			info.push(`**${category}**\`\`\`${commands[category].sort().join("\n")}\`\`\``);
 		});
-		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <${config.hosting_url}/wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
+		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <https://awesomebot.xyz/wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
 
 		msg.author.getDMChannel().then(ch => {
 			bot.sendArray(ch, info);

--- a/Commands/Public/help.js
+++ b/Commands/Public/help.js
@@ -1,7 +1,7 @@
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix) => {
 	if(suffix) {
 		const getCommandHelp = (name, type, usage, description) => {
-			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<https://awesomebot.xyz/wiki/Commands#${name}>`;
+			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<${config.hosting_url}wiki/Commands#${name}>`;
 		};
 
 		const info = [];
@@ -35,7 +35,7 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		Object.keys(commands).sort().forEach(category => {
 			info.push(`**${category}**\`\`\`${commands[category].sort().join("\n")}\`\`\``);
 		});
-		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <https://awesomebot.xyz/wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
+		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <${config.hosting_url}/wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
 
 		msg.author.getDMChannel().then(ch => {
 			bot.sendArray(ch, info);

--- a/Commands/Public/help.js
+++ b/Commands/Public/help.js
@@ -1,7 +1,7 @@
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix) => {
 	if(suffix) {
 		const getCommandHelp = (name, type, usage, description) => {
-			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<https://awesomebot.xyz/wiki/Commands#${name}>`;
+			return `__Help for ${type} command **${name}**__\n${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}<${config.hosting_url}wiki/Commands#${name}>`;
 		};
 
 		const info = [];
@@ -35,7 +35,7 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		Object.keys(commands).sort().forEach(category => {
 			info.push(`**${category}**\`\`\`${commands[category].sort().join("\n")}\`\`\``);
 		});
-		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <https://awesomebot.xyz/wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
+		info.push(`For detailed information about each command and all of AwesomeBot's other features, head over to our wiki: <${config.hosting_url}wiki/Commands>. If you need support using AwesomeBot, please join our Discord server: <${config.discord_link}>. Have fun! 🙂🐬`);
 
 		msg.author.getDMChannel().then(ch => {
 			bot.sendArray(ch, info);


### PR DESCRIPTION
Link to awesomebot.xyz homepage in about.js removed and (joint) credits updated to match the kind on
the GAB home page. Help commands amended to link to hosting_url/wiki instead of awesomebot wiki (which no longer exists).

On a separate note unrelated to GAB itself, the help command on the current GAB instance links to `https://bot.gilbertgobbels.xyz/wiki/`, which is broken as the port is missing from the URL. This would fix that too, by using the hosting URL defined in config.