### PR TITLE
Updated about links

### DIFF
--- a/Commands/Public/about.js
+++ b/Commands/Public/about.js
@@ -1,7 +1,7 @@
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix) => {
 	if(suffix && ["bug", "suggestion", "feature", "issue"].indexOf(suffix.toLowerCase())>-1) {
-		msg.channel.createMessage(`🐜 Please file your ${suffix.toLowerCase()} here: https://github.com/BitQuote/AwesomeBot/issues/new`);
+		msg.channel.createMessage(`🐜 Please file your ${suffix.toLowerCase()} here: https://github.com/GilbertGobbels/GAwesomeBot/issues/new`);
 	} else {
-		msg.channel.createMessage(`Hello! I'm AwesomeBot, the best discord bot! 🐬 Use \`${bot.getCommandPrefix(msg.guild, serverDocument)}help\` to list commands. Created by BitQuote. Built on NodeJS with Eris. Go to <https://awesomebot.xyz/> to learn more, or join our Discord server: <${config.discord_link}>`);
+		msg.channel.createMessage(`Hello! I'm GAwesomeBot, the best discord bot! 🐬 Use \`${bot.getCommandPrefix(msg.guild, serverDocument)}help\` to list commands. Developed by Gilbert, based off AB by BitQuote. Built on NodeJS with Eris. Go to <https://bot.gilbertgobbels.xyz:8008/> to learn more, or join our Discord server: <https://discord.gg/gDtzaS2>`);
 	}
 };


### PR DESCRIPTION
Changed bug/suggestion reporting to link to GAwesomeBot GitHub instead
of AB.

Updated bot title and credits to match the GAB home page.

Changed the AB url to GAB's home page. It didn't make sense leaving the
Discord link as `config.discord_url` unless the home page was also the
self-host URL (but that didn't seem sensible either), so I changed this
to GAB's Discord link as well.