### PR TITLE
Updated usage for messages and kick commands

### DIFF
--- a/Configuration/commands.json
+++ b/Configuration/commands.json
@@ -407,7 +407,7 @@
             "category": "Fun 🎪"
         },
         "kick": {
-            "usage": "<user>",
+            "usage": "<user>[|<reason>]",
             "description": "Removes a member from the server",
             "defaults": {
                 "is_enabled": true,

--- a/Configuration/commands.json
+++ b/Configuration/commands.json
@@ -457,7 +457,7 @@
             "category": "Fun 🎪"
         },
         "messages": {
-            "usage": "[<user>]",
+            "usage": "[<user or \"me\">]",
             "description": "Command that shows the top members on the server by activity",
             "defaults": {
                 "is_enabled": true,


### PR DESCRIPTION
The messages command in AB4 still supports the 'me' suffix, but the command usage does not reflect this.
Likewise, the kick command also supports the optional reason suffix, but the usage does not reflect this.