### PR TITLE
Fixed user mentions for extensions

### DIFF
--- a/Modules/ExtensionStructures/Message.js
+++ b/Modules/ExtensionStructures/Message.js
@@ -22,17 +22,6 @@ class Message {
 		this.timestamp = erisMessage.timestamp;
 		this.tts = erisMessage.tts;
 
-		this.mentions = () => {
-			const Collection = require("./Collection");
-			const User = require("./User");
-
-			const mentions = new Collection(User);
-			mentions.forEach(user => {
-				this.mentions.add(new User(user));
-			});
-			return mentions;
-		};
-
 		this.delete = cb => {
 			erisMessage.delete().then(() => {
 				if(Util.isFunction(cb)) {
@@ -86,6 +75,25 @@ class Message {
 		const Member = require("./Member");
 		return new Member(g_erisMessage.member);
 	}
+    
+    get mentions() {
+        const Member = require("./Member");
+        const list = g_erisMessage.mentions;
+        const content = (g_erisMessage.content.match(/<@!?[0-9]+>/g) || []).map(function(uid){return uid.replace(/[^0-9.]/g, '')});
+        const musers  = content.filter(function(item, pos, self) { return self.indexOf(item) == pos });
+        const order = [];
+        const mentions = [];
+        
+        for(var i=0; i<list.length; i++){
+            var ix = musers.indexOf(list[i].id);
+            if(ix > -1) order[ix] = i;
+        }
+        for(var i=0; i<order.length; i++) {
+            mentions.push(new Member(list[order[i]]));
+        }
+        return mentions;
+    }
+
 }
 
 module.exports = Message;


### PR DESCRIPTION
When run from an extension, message.mentions now returns an array of Member objects. For some bizarre reason Eris returns the mentions array by user ID in ascending order (totally illogical, in my opinion), so
through cumbersome means I've reordered the array in order of the user mentioned in the message. The snag is that multiple mentions of the _same_ user will be substituted for a single mention (but why would anyone do that?)

Probably not the most elegant solution possible, but it solves the problem of mentions not working, puts mentions in order and passes additional user information about mentioned users, such as AvatarURL, status, etc. to extensions.