### PR TITLE
Weather unit added to profile

### DIFF
--- a/Commands/PM/profile.js
+++ b/Commands/PM/profile.js
@@ -92,7 +92,25 @@ module.exports = (bot, db, config, winston, userDocument, msg, suffix, commandDa
 						userDocument.location = args[1].trim();
 					}
 					saveUserDocument();
-				} else if(userDocument.profile_fields && userDocument.profile_fields[key]) {
+				}
+				else if(key.toLowerCase()=="weatherunit") {
+					if(!args[1] || args[1].trim()==".") {
+						userDocument.weatherunit = null;
+						saveUserDocument();
+					}
+					else if(args[1].trim().toLowerCase() == "fahrenheit" || args[1].trim().toLowerCase() == "f"){
+						userDocument.weatherunit = "Fahrenheit";
+						saveUserDocument();
+					}
+					else if(args[1].trim().toLowerCase() == "celsius" || args[1].trim().toLowerCase() == "c"){
+						userDocument.weatherunit = "Celsius";
+						saveUserDocument();
+					}
+					else {
+						msg.channel.createMessage(`Invalid weather unit specified. Please specify either fahrenheit or celsius.`);
+					}
+				}
+				else if(userDocument.profile_fields && userDocument.profile_fields[key]) {
 					if(!args[1] || args[1].trim()==".") {
 						setProfileField(true);
 					} else {
@@ -113,6 +131,7 @@ module.exports = (bot, db, config, winston, userDocument, msg, suffix, commandDa
 			}
 		} else {
 			if(suffix.toLowerCase() == "location" && userDocument.location) { msg.channel.createMessage(userDocument.location); }
+			else if(suffix.toLowerCase() == "weatherunit" && userDocument.weatherunit) { msg.channel.createMessage(userDocument.weatherunit); }
 			else if(userDocument.profile_fields && userDocument.profile_fields[suffix]) {
 				msg.channel.createMessage(userDocument.profile_fields[suffix]);
 			} else {

--- a/Commands/Public/weather.js
+++ b/Commands/Public/weather.js
@@ -1,7 +1,8 @@
 const weather = require("weather-js");
 
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix, commandData) => {
-	let unit = "F";
+	let unit = "C";
+	if(userDocument.weatherunit && userDocument.weatherunit == "Fahrenheit") unit = "F";
 	if([" F", " C"].indexOf(suffix.toUpperCase().substring(suffix.length-2))>-1) {
 		unit = suffix.charAt(suffix.length-1).toUpperCase().toString();
 		suffix = suffix.substring(0, suffix.length-2);

--- a/Database/Schemas/userSchema.js
+++ b/Database/Schemas/userSchema.js
@@ -15,6 +15,7 @@ module.exports = new mongoose.Schema({
 		expiry_timestamp: {type: Date, required: true}
 	})],
 	location: String,
+	weatherunit: String,
 	last_seen: Date,
 	profile_fields: mongoose.Schema.Types.Mixed,
 	profile_background_image: {type: String, default: "http://i.imgur.com/8UIlbtg.jpg"},


### PR DESCRIPTION
The default temperature unit for the weather command was Fahrenheit, but
this is uncommon in most of the world (which uses Celsius). Setting to F
or C is problematic because whoever doesn't use the default is forced to
define the temperature unit every time they use the weather command.

For example, if a user wants to see the weather in Paris in Celsius they
must type `weather Paris C`. If that user then sets their profile
location to Paris, they can simply run `weather`. But this convenience
is undermined by the fact that `weather` will show them the weather in
Paris in **Fahrenheit**. So despite setting their profile location, they
must run `weather Paris C` every time.

My initial thought was to simply set the default to C, but this causes
the inverse problem for those using Fahrenheit (although we know who
[they are](https://qph.ec.quoracdn.net/main-qimg-4b106c00694e6ceefd236d40928d9a3f-c)).

So I've instead added a new key to the user profile schema: weatherunit.
A user can now PM `profile weatherunit|<fahrenheit or celsius>` and the
weather command will in future respond according to their preference,
defaulting to Celsius if the weatherunit key has not been set.