### PR TITLE
Added (empty) Extensions directory

### DIFF
--- a/Extensions/.gitignore
+++ b/Extensions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
New installs still require manual creation of an empty Extensions
directory, otherwise extensions won't save. I've updated the instance
self-host guide to specify that the directory should be created, but
this is the simpler solution.