### PR TITLE
Always pass full user property via member object

### DIFF
--- a/Modules/ExtensionStructures/Member.js
+++ b/Modules/ExtensionStructures/Member.js
@@ -24,6 +24,10 @@ module.exports = class Member {
 		this.defaultAvatarURL = erisMember.defaultAvatarURL;
 		this.discriminator = erisMember.discriminator;
 		this.username = erisMember.username;
+		
+		//pass g_erisMember.user object now
+		const User = require("./User");
+		this.user = new User(g_erisMember.user);
 
 		// functions
 		this.ban = (deleteMessageDays, cb) => {
@@ -67,11 +71,6 @@ module.exports = class Member {
 	get permission() {
 		const Permission = require("./Permission");
 		return new Permission(g_erisMember.permission);
-	}
-
-	get user() {
-		const User = require("./User");
-		return new User(g_erisMember.user);
 	}
 
 	get voiceState() {


### PR DESCRIPTION
In extensions, there are times when the user object and member object are needed for different purposes. For example, when we want to PM a member from an extension, we need their user object so we can call [userobj].createMessage().

If we have the user object through message.author, this is fine. But beyond author, extensions only retrieve *member* objects. e.g. through guild.members.get(id) or through message.mentions[x]. In these cases, we need the user object (as it contains getDMChannel() from eris, and createMessage() in User.js takes care of the rest).

The eris Member object contains a .user property, so the user object passes with Member. This *should* allow us to be able to get the user object. But in extensions (Member.js), the user
object is passed via a getter, and this means that in some cases that while user.createMessage is still defined, functions like getDMChannel() within the eris User object are not (see
issue #50 ).

There is also an issue whereby message.mentions[x].user returns the bot's user object rather than the relevant member's. While individual modifications could be made to instances like that, this solution resolves these problems and will also resolve any further issues that may arise where trying to retrieve a user object from a member object in an extension.