### PR TITLE
Fixed trivia

### DIFF
--- a/Modules/Trivia.js
+++ b/Modules/Trivia.js
@@ -31,7 +31,7 @@ module.exports = {
 			const doNext = () => {
 				let set = defaultTriviaSet;
 				if(channelDocument.trivia.set_id!="default") {
-					set = serverDocument.config.trivia_sets.id(set);
+					set = serverDocument.config.trivia_sets.id(channelDocument.trivia.set_id).items;
 				}
 				if(set) {
 					const question = module.exports.question(set, channelDocument);

--- a/Web/WebServer.js
+++ b/Web/WebServer.js
@@ -3240,7 +3240,7 @@ module.exports = (bot, db, auth, config, winston) => {
 								name: ch.name,
 								id: ch.id
 							},
-							set: channelDocument.trivia.set,
+							set: channelDocument.trivia.set_id,
 							score: channelDocument.trivia.score,
 							max_score: channelDocument.trivia.max_score,
 							responders: channelDocument.trivia.responders.length


### PR DESCRIPTION
Trivia was previously broken with custom sets. The trivia game would end immediately, as when using a custom set, Trivia.js had not properly defined the custom trivia JSON and did not cater for the fact that once imported to the database, the items exist under an 'items' property.

Additionally, when browsing the Ongoing Activities page of the Admin Console, an error was returned and the page inaccessible. This was due to WebServer.js erroneously passing a non-existent variable (set instead of set_id) from the channel's trivia property.

Custom trivia sets now working, and the ongoing activities page works as intended when trivia games are ongoing.