### PR TITLE
Fixed crash on mute when a filter is triggered

### DIFF
--- a/Platform/Discord.js
+++ b/Platform/Discord.js
@@ -423,7 +423,7 @@ module.exports = (db, auth, config) => {
 				blockMember();
 				break;
 			case "mute":
-				bot.muteMember(ch, member).then(err => {
+				bot.muteMember(ch, member, err => {
 					if(err) {
 						blockMember();
 					} else {


### PR DESCRIPTION
A simple fix to resolve the crash that occurs as a result of 'then' being undefined when bot.muteMember is triggered on a filter, per issue #64.