### PR TITLE
Added roleAdd and roleRemove to extension Member API

### DIFF
--- a/Modules/ExtensionStructures/Member.js
+++ b/Modules/ExtensionStructures/Member.js
@@ -61,6 +61,22 @@ module.exports = class Member {
 				}
 			});
 		};
+        
+        this.addRole = (roleID, cb) => {
+			erisMember.addRole(roleID).then(() => {
+				if(Util.isFunction(cb)) {
+					cb();
+				}
+			});
+		};
+        
+        this.removeRole = (roleID, cb) => {
+            erisMember.removeRole(roleID).then(() => {
+				if(Util.isFunction(cb)) {
+					cb();
+				}
+			});
+		};
 	}
 
 	get guild() {


### PR DESCRIPTION
Adding a member to/removing a member from a role is possible within an extension however the method is a little cumbersome. The extension must get the user's current roles array into a variable, then either push to or slice that array before then using the edit method i.e. `message.member.edit({ roles: arrayvar }).`

Eris already has Member.addRole/removeRole functions, and it seems both sensible and convenient to make them available to extensions.