### PR TITLE
Fixed numerous issues with giveaway

### DIFF
--- a/Commands/PM/giveaway.js
+++ b/Commands/PM/giveaway.js
@@ -38,18 +38,7 @@ module.exports = (bot, db, config, winston, userDocument, msg, suffix, commandDa
 											}).then(() => {
 												bot.awaitMessage(msg.channel.id, msg.author.id, message => {
 													if(config.yes_strings.indexOf(message.content.toLowerCase().trim()) > -1) {
-														const winner = Giveaways.end(bot, svr, serverDocument, ch, channelDocument);
-														msg.channel.createMessage({
-															embed: {
-                                                                author: {
-                                                                    name: bot.user.username,
-                                                                    icon_url: bot.user.avatarURL,
-                                                                    url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                                                                },
-                                                                color: 0x00FF00,
-																description: `Alright, giveaway ended.\n${winner ? (`The winner was **@${bot.getName(svr, serverDocument, winner)}**`) : "I couldn't choose a winner for some reason tho 😕"}`
-															}
-														});
+														const endgiveaway = Giveaways.end(bot, db, svr, ch);
 													}
 												});
 											});
@@ -134,10 +123,10 @@ module.exports = (bot, db, config, winston, userDocument, msg, suffix, commandDa
 															const title = message.content.trim();
 															msg.channel.createMessage("How long do you want this giveaway to last? 🕰 Type `.` to use the default of 1 hour.").then(() => {
 																bot.awaitMessage(msg.channel.id, msg.author.id, message => {
-																	let duration = message.content.trim()=="." ? 3600000 : parseDuration(message);
-																	
+																	let duration = message.content.trim()=="." ? 3600000 : parseDuration(message.content);
+
 																	const start = () => {
-																		Giveaways.start(bot, svr, serverDocument, msg.author, ch, channelDocument, title, secret, duration);
+																		Giveaways.start(bot, db, svr, serverDocument, msg.author, ch, channelDocument, title, secret, duration);
 																		msg.channel.createMessage("Giveaway started! 🎯 *I'm excited*");
 																	};
 

--- a/Modules/Giveaways.js
+++ b/Modules/Giveaways.js
@@ -1,5 +1,5 @@
 module.exports = {
-	start: (bot, svr, serverDocument, usr, ch, channelDocument, title, secret, duration) => {
+	start: (bot, db, svr, serverDocument, usr, ch, channelDocument, title, secret, duration) => {
 		if(!channelDocument.giveaway.isOngoing) {
 			channelDocument.giveaway.isOngoing = true;
 			channelDocument.giveaway.expiry_timestamp = Date.now() + duration;
@@ -20,53 +20,72 @@ module.exports = {
 					}
 				});
 				setTimeout(() => {
-					module.exports.end(bot, svr, serverDocument, ch, channelDocument);
+					module.exports.end(bot, db, svr, ch);
 				}, duration);
 			});
 		}
 	},
-	end: (bot, svr, serverDocument, ch, channelDocument) => {
-		if(channelDocument.giveaway.isOngoing) {
-			channelDocument.giveaway.isOngoing = false;
-			let winner;
-			while(!winner && channelDocument.giveaway.participant_ids.length > 0) {
-				const i = Math.floor(Math.random() * channelDocument.giveaway.participant_ids.length);
-				const member = svr.members.get(channelDocument.giveaway.participant_ids[i]);
-				if(member) {
-					winner = member;
-				} else {
-					channelDocument.giveaway.participant_ids.splice(i, 1);
-				}
-			}
-			serverDocument.save(() => {
-				if(winner) {
-					ch.createMessage({
-						embed: {
-                            author: {
-                                name: bot.user.username,
-                                icon_url: bot.user.avatarURL,
-                                url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                            },
-                            color: 0x00FF00,
-							description: `Congratulations **@${bot.getName(svr, serverDocument, winner)}**! 🎊 You won the giveaway **${channelDocument.giveaway.title}** out of ${channelDocument.giveaway.participant_ids.length} ${channelDocument.giveaway.participant_ids.length==1 ? "person" : "people"}.`
-						}
-					});
-					winner.user.getDMChannel().then(channel => {
-						channel.createMessage({
-							embed: {
+	end: (bot, db, svr, ch) => {
+        db.servers.findOne({_id: svr.id}, (err, serverDocument) => {
+            const channelDocument = serverDocument.channels.id(ch.id);
+            if(channelDocument.giveaway.isOngoing) {
+                channelDocument.giveaway.isOngoing = false;
+                let winner;
+                while(!winner && channelDocument.giveaway.participant_ids.length > 0) {
+                    const i = Math.floor(Math.random() * channelDocument.giveaway.participant_ids.length);
+                    const member = svr.members.get(channelDocument.giveaway.participant_ids[i]);
+                    if(member) {
+                        winner = member;
+                    } else {
+                        channelDocument.giveaway.participant_ids.splice(i, 1);
+                    }
+                }
+                serverDocument.save(() => {
+                    if(winner) {
+                        ch.createMessage({
+                            embed: {
                                 author: {
                                     name: bot.user.username,
                                     icon_url: bot.user.avatarURL,
                                     url: "https://github.com/GilbertGobbels/GAwesomeBot"
                                 },
                                 color: 0x00FF00,
-								description: `Congratulations! 🎁😁 You won the giveaway in #${ch.name} on ${svr.name}:\`\`\`${channelDocument.giveaway.secret}\`\`\``
-							}
-						});
-					});
-				}
-			});
-			return winner;
-		}
-	}
+                                description: `Congratulations **@${bot.getName(svr, serverDocument, winner)}**! 🎊 You won the giveaway **${channelDocument.giveaway.title}** out of ${channelDocument.giveaway.participant_ids.length} ${channelDocument.giveaway.participant_ids.length==1 ? "person" : "people"}.`
+                            }
+                        });
+                        winner.user.getDMChannel().then(channel => {
+                            channel.createMessage({
+                                embed: {
+                                    author: {
+                                        name: bot.user.username,
+                                        icon_url: bot.user.avatarURL,
+                                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
+                                    },
+                                    color: 0x00FF00,
+                                    description: `Congratulations! 🎁😁 You won the giveaway in #${ch.name} on ${svr.name}:\`\`\`${channelDocument.giveaway.secret}\`\`\``
+                                }
+                            });
+                        });
+                    }
+                    const creator = svr.members.get(channelDocument.giveaway.creator_id);
+                    if(creator){
+                        creator.user.getDMChannel().then(channel => {
+                            channel.createMessage({
+                                embed: {
+                                    author: {
+                                        name: bot.user.username,
+                                        icon_url: bot.user.avatarURL,
+                                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
+                                    },
+                                    color: 0x00FF00,
+                                    description: `Your giveaway "${channelDocument.giveaway.title}" running in <#${ch.id}> has ended.` + `\n${winner ? (`The winner was **@${bot.getName(svr, serverDocument, winner)}**`) : "I couldn't choose a winner for some reason tho 😕"}`
+                                }
+                            });
+                        });
+                    }
+                });
+                return winner;
+            }
+        });
+    }
 };


### PR DESCRIPTION
1) The giveaway command was ignoring any duration other than the default (per issue #70).

2) Giveaways were not ending by themselves at the conclusion of the period set. They could only be ended manually by the creator via PM.

This was because Giveaways.end(), when triggered on a setTimeout() by Giveaways.start() was passing the channelDocument as it was when the giveaway began (thus meaning the participant_ids array was always empty). On the other hand, when ended manually, the channelDocument that was passed to Giveaways.end() was up to date.

Giveaways.end() has been updated to use the live channelDocument, and consequently the problem has been eliminated.

3) The success message PM'd to the creator would always say a winner could not be chosen, even where a winner had been chosen. Also, the creator would only be PM'd the results of their giveaway when they forcefully ended it by PM. I have resolved both these issues by removing the PM from the manual end awaitMessage() in giveaways.js and altering the Giveaways.end() function to always PM the creator at the conclusion of their giveaway, regardless of how it ended. The PM also now correctly identifies the winning user.