### PR TITLE
Fixed channel.editMessage (extensions)

### DIFF
--- a/Modules/ExtensionStructures/Channel.js
+++ b/Modules/ExtensionStructures/Channel.js
@@ -33,8 +33,8 @@ module.exports = class Channel {
 			});
 		};
 
-		this.editMessage = (messageID, cb) => {
-			erisChannel.editMessage(messageID).then(erisMessage => {
+		this.editMessage = (messageID, content, cb) => {
+			erisChannel.editMessage(messageID, content).then(erisMessage => {
 				if(Util.isFunction(cb)) {
 					const Message = require("./Message");
 					cb(new Message(erisMessage));


### PR DESCRIPTION
channel.editMessage in Channel.js did not pass the content parameter, so it didn't work. Simple fix. Now works as it should.