### PR TITLE
Improvements to Guild (extensions)

### DIFF
--- a/Modules/ExtensionStructures/Guild.js
+++ b/Modules/ExtensionStructures/Guild.js
@@ -54,8 +54,8 @@ module.exports = class Guild {
 			});
 		};
 
-		this.createRole = cb => {
-			erisGuild.createRole().then(erisRole => {
+		this.createRole = (options, cb) => {
+			erisGuild.createRole(options).then(erisRole => {
 				if(Util.isFunction(cb)) {
 					const Role = require("./Role");
 					cb(new Role(erisRole));

--- a/Modules/ExtensionStructures/Guild.js
+++ b/Modules/ExtensionStructures/Guild.js
@@ -139,16 +139,6 @@ module.exports = class Guild {
 			});
 		};
 
-		this.getChannels = cb => {
-			erisGuild.getChannels().then(erisGuildChannels => {
-				if(Util.isFunction(cb)) {
-					const GuildChannel = require("./GuildChannel");
-					const GuildChannels = erisGuildChannels.map(erisGuildChannel => new GuildChannel(erisGuildChannel));
-					cb(GuildChannels);
-				}
-			});
-		};
-
 		this.getEmbed = cb => {
 			erisGuild.getEmbed().then(object => {
 				if(Util.isFunction(cb)) {

--- a/Modules/ExtensionStructures/Guild.js
+++ b/Modules/ExtensionStructures/Guild.js
@@ -165,16 +165,6 @@ module.exports = class Guild {
 			});
 		};
 
-		this.getRoles = cb => {
-			erisGuild.getRoles().then(erisRoles => {
-				if(Util.isFunction(cb)) {
-					const Role = require("./Role");
-					const Roles = erisRoles.map(erisRole => new Role(erisRole));
-					cb(Roles);
-				}
-			});
-		};
-
 		this.getVoiceRegions = cb => {
 			erisGuild.getVoiceRegions().then(objects => {
 				if(Util.isFunction(cb)) {

--- a/Modules/ExtensionStructures/Guild.js
+++ b/Modules/ExtensionStructures/Guild.js
@@ -147,22 +147,6 @@ module.exports = class Guild {
 			});
 		};
 
-		this.getEmoji = (emojiID, cb) => {
-			erisGuild.getEmoji(emojiID).then(object => {
-				if(Util.isFunction(cb)) {
-					cb(object);
-				}
-			});
-		};
-
-		this.getEmojis = cb => {
-			erisGuild.getEmojis().then(objects => {
-				if(Util.isFunction(cb)) {
-					cb(objects);
-				}
-			});
-		};
-
 		this.getInvites = cb => {
 			erisGuild.getInvites().then(erisInvites => {
 				if(Util.isFunction(cb)) {

--- a/Modules/ExtensionStructures/Guild.js
+++ b/Modules/ExtensionStructures/Guild.js
@@ -157,25 +157,6 @@ module.exports = class Guild {
 			});
 		};
 
-		this.getMember = (memberID, cb) => {
-			erisGuild.getMember(memberID).then(erisMember => {
-				if(Util.isFunction(cb)) {
-					const Member = require("./Member");
-					cb(new Member(erisMember));
-				}
-			});
-		};
-
-		this.getMembers = (limit, after, cb) => {
-			erisGuild.getMembers(limit, after).then(erisMembers => {
-				if(Util.isFunction(cb)) {
-					const Member = require("./Member");
-					const Members = erisMembers.map(erisMember => new Member(erisMember));
-					cb(Members);
-				}
-			});
-		};
-
 		this.getPruneCount = (days, cb) => {
 			erisGuild.getPruneCount(days).then(num => {
 				if(Util.isFunction(cb)) {


### PR DESCRIPTION
**Added options parameter to Guild.createRole() (extensions)**:

The options parameter remains optional, but if we don't pass it to the function, we then have to use the callback and run Role.edit() on it to specify options for the role we've created. It is much more efficient to be able to specify options when creating a role in the first place. It looks as though this was left out of the original code by mistake.

**Removed non-existent Guild.getChannels**:
Using Guild.getChannels results in:
```
TypeError: erisGuild.getChannels is not a function at Guild.getChannels.cb [as getChannels] (Modules/ExtensionStructures/Guild.js:143:14)
```
Reason: erisGuild.getChannels is indeed _not_ a function. It [doesn't exist](https://abal.moe/Eris/docs/Guild). Also, Guild.channels() is already made available in extensions and works just fine. So there's no need for Guild.getChannels.

**Removed getEmoji and getEmojis as neither exists**:

Same as above. Neither erisGuild.getEmoji/getEmojis exists, so these functions are useless. Guild.emojis() is already available anyway.

**Removed getMember and getMembers as neither exists**:

You guessed it! `erisGuild.getMember is not a function at Guild.getMember...` Both functions will not work, so removed. Guild.members() already available also. As for getMember, Guild.members.get(ID) works... and it won't break an extension ;)

**Removed erisGuild.getRoles as it doesn't exist**
`erisGuild.getRoles is not a function`. Guild.roles() already available.
