### PR TITLE
Always pass member.permission in extensions

### DIFF
--- a/Modules/ExtensionStructures/Member.js
+++ b/Modules/ExtensionStructures/Member.js
@@ -28,6 +28,10 @@ module.exports = class Member {
 		//pass g_erisMember.user object now
 		const User = require("./User");
 		this.user = new User(g_erisMember.user);
+        
+        //pass g_erisMember.permission object now
+        const Permission = require("./Permission");
+        this.permission = new Permission(g_erisMember.permission);
 
 		// functions
 		this.ban = (deleteMessageDays, cb) => {
@@ -66,11 +70,6 @@ module.exports = class Member {
 	get guild() {
 		const Guild = require("./Guild");
 		return new Guild(g_erisMember.guild);
-	}
-
-	get permission() {
-		const Permission = require("./Permission");
-		return new Permission(g_erisMember.permission);
 	}
 
 	get voiceState() {


### PR DESCRIPTION
For the same reason that getters have in some instances caused problems in extensions (such as with mentions), this change is a must. Otherwise, member.permissions can return _the bot's_ permissions object and not the member's. Try creating an extension with `logMsg(JSON.stringify(message.mentions[0].permission))` and mention various users. You'll see it doesn't return correct permissions objects.  After switching from a getter, works perfectly (as expected ;))