### PR TITLE
Fixed Role.permissions (extensions) as was empty

### DIFF
--- a/Modules/ExtensionStructures/Role.js
+++ b/Modules/ExtensionStructures/Role.js
@@ -17,7 +17,8 @@ module.exports = class Role {
 		this.name = erisRole.name;
 		this.position = erisRole.position;
 
-		this.asJSON = erisRole.asJSON;
+		const Permission = require("./Permission");
+        this.permissions = new Permission(g_erisRole.permissions);
 
 		this.delete = cb => {
 			erisRole.delete().then(() => {
@@ -48,10 +49,5 @@ module.exports = class Role {
 	get guild() {
 		const Guild = require("./Guild");
 		return new Guild(g_erisRole.guild);
-	}
-
-	get permissions() {
-		const Permission = require("./Permission");
-		return new Permission(g_erisRole.permissions);
 	}
 };

--- a/Modules/ExtensionStructures/Role.js
+++ b/Modules/ExtensionStructures/Role.js
@@ -18,7 +18,7 @@ module.exports = class Role {
 		this.position = erisRole.position;
 
 		const Permission = require("./Permission");
-        this.permissions = new Permission(g_erisRole.permissions);
+		this.permissions = new Permission(g_erisRole.permissions);
 
 		this.delete = cb => {
 			erisRole.delete().then(() => {


### PR DESCRIPTION
Role.permissions frequently empty. To reproduce:

```
logMsg(JSON.stringify(guild.roles.get(ROLE ID).permissions));
```

Even for a role with full administrative permissions, the result is:

`{"allow":0,"deny":0,"json":{}}`

As has been the problem with numerous other properties (e.g. Member.permissions in issue #77), the fault lies in the fact that permissions() was a getter. By always passing permissions the problem is avoided and Role permissions are able to be properly read and used.

I've also removed Role.asJSON. As with some properties attempted to be used in Guild.js (issue #76), erisRole.asJSON does not exist. It used to exist, before Eris devs replaced it with erisRole.json(). See [here](https://github.com/abalabahaha/eris/pull/111).

Even still, erisRole.json would not be necessary as it already accessible by Role.permissions.json.