### PR TITLE
Fixed Invite.inviter (extensions) as was empty

### DIFF
--- a/Modules/ExtensionStructures/Invite.js
+++ b/Modules/ExtensionStructures/Invite.js
@@ -16,6 +16,12 @@ module.exports = class Invite {
 		this.revoked = erisInvite.revoked;
 		this.temporary = erisInvite.temporary;
 		this.uses = erisInvite.users;
+        
+		this.inviter = null;
+		if(g_erisInvite.inviter) {
+            const User = require("./User");
+            this.inviter = new User(g_erisInvite.inviter);
+		}
 
 		this.delete = cb => {
 			erisInvite.delete().then(() => {
@@ -24,14 +30,5 @@ module.exports = class Invite {
 				}
 			});
 		};
-	}
-
-	get inviter() {
-		let inviter = null;
-		if(g_erisInvite.inviter) {
-			const User = require("./User");
-			inviter = new User(g_erisInvite.inviter);
-		}
-		return inviter;
 	}
 };

--- a/Modules/ExtensionStructures/Invite.js
+++ b/Modules/ExtensionStructures/Invite.js
@@ -16,11 +16,11 @@ module.exports = class Invite {
 		this.revoked = erisInvite.revoked;
 		this.temporary = erisInvite.temporary;
 		this.uses = erisInvite.users;
-        
+
 		this.inviter = null;
 		if(g_erisInvite.inviter) {
-            const User = require("./User");
-            this.inviter = new User(g_erisInvite.inviter);
+			const User = require("./User");
+			this.inviter = new User(g_erisInvite.inviter);
 		}
 
 		this.delete = cb => {


### PR DESCRIPTION
As has been the problem with numerous other properties, Inviter was a getter. This meant the invite creator's user object wasn't passing with the Invite object and wasn't retrievable (an extension could not even see which user created the invite).

To reproduce: `guild.getInvites(cb => {logMsg(JSON.stringify(cb))});`

Resolved by always passing the User object via .inviter.