### PR TITLE
Modlog command always returning disabled even when enabled

### DIFF
--- a/Commands/Public/modlog.js
+++ b/Commands/Public/modlog.js
@@ -7,24 +7,24 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 				winston.error(`Failed to delete modlog entry on server '${msg.guild.name}'`, {svrid: msg.guild.id}, err);
 				msg.channel.createMessage({
 					embed: {
-                        author: {
-                            name: bot.user.username,
-                            icon_url: bot.user.avatarURL,
-                            url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                        },
-                        color: 0xFF0000,
+			            author: {
+			              	name: bot.user.username,
+			              	icon_url: bot.user.avatarURL,
+			              	url: "https://github.com/GilbertGobbels/GAwesomeBot"
+			            },
+			            color: 0xFF0000,
 						description: "Oh no! Something went wrong. 🥀 Make sure moderation logging is enabled and that you provided a valid case ID number."
 					}
 				});
 			} else {
 				msg.channel.createMessage({
 					embed: {
-                        author: {
-                            name: bot.user.username,
-                            icon_url: bot.user.avatarURL,
-                            url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                        },
-                        color: 0x00FF00,
+			            author: {
+			              	name: bot.user.username,
+			              	icon_url: bot.user.avatarURL,
+			              	url: "https://github.com/GilbertGobbels/GAwesomeBot"
+			            },
+			            color: 0x00FF00,
 						description: `Done! Case #${id} is gone 💨`
 					}
 				});
@@ -35,12 +35,12 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		if(!serverDocument.modlog.isEnabled || !serverDocument.modlog.channel_id) {
 			msg.channel.createMessage({
 				embed: {
-                    author: {
-                        name: bot.user.username,
-                        icon_url: bot.user.avatarURL,
-                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                    },
-                    color: 0xFF0000,
+		          	author: {
+		            	name: bot.user.username,
+		            	icon_url: bot.user.avatarURL,
+		            	url: "https://github.com/GilbertGobbels/GAwesomeBot"
+		          	},
+          			color: 0xFF0000,
 					description: "Moderation logging is not enabled. ✋"
 				}
 			});
@@ -49,12 +49,12 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 			serverDocument.modlog.channel_id = null;
 			msg.channel.createMessage({
 				embed: {
-                    author: {
-                        name: bot.user.username,
-                        icon_url: bot.user.avatarURL,
-                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                    },
-                    color: 0x00FF00,
+					author: {
+						name: bot.user.username,
+						icon_url: bot.user.avatarURL,
+						url: "https://github.com/GilbertGobbels/GAwesomeBot"
+						},
+					color: 0x00FF00,
 					description: "Moderation logging is now disabled. ❎"
 				}
 			});
@@ -68,24 +68,24 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 				serverDocument.modlog.channel_id = ch.id;
 				msg.channel.createMessage({
 					embed: {
-                        author: {
-                            name: bot.user.username,
-                            icon_url: bot.user.avatarURL,
-                            url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                        },
-                        color: 0x00FF00,
+						author: {
+							name: bot.user.username,
+							icon_url: bot.user.avatarURL,
+							url: "https://github.com/GilbertGobbels/GAwesomeBot"
+						},
+						color: 0x00FF00,
 						description: `Moderation logging enabled in ${ch.mention} 🙌`
 					}
 				});
 			} else {
 				msg.channel.createMessage({
 					embed: {
-                        author: {
-                            name: bot.user.username,
-                            icon_url: bot.user.avatarURL,
-                            url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                        },
-                        color: 0xFF0000,
+						author: {
+							name: bot.user.username,
+							icon_url: bot.user.avatarURL,
+			              	url: "https://github.com/GilbertGobbels/GAwesomeBot"
+						},
+						color: 0xFF0000,
 						description: `Unable to find channel \`${chname}\` 🚫`
 					}
 				});
@@ -93,12 +93,12 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		} else {
 			msg.channel.createMessage({
 				embed: {
-                    author: {
-                        name: bot.user.username,
-                        icon_url: bot.user.avatarURL,
-                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                    },
-                    color: 0xFF0000,
+          			author: {
+            			name: bot.user.username,
+            			icon_url: bot.user.avatarURL,
+            			url: "https://github.com/GilbertGobbels/GAwesomeBot"
+          			},
+          			color: 0xFF0000,
 					description: "A channel is required to enable moderation logging. 👐"
 				}
 			});
@@ -119,13 +119,13 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		default:
 			msg.channel.createMessage({
 				embed: {
-                    author: {
-                        name: bot.user.username,
-                        icon_url: bot.user.avatarURL,
-                        url: "https://github.com/GilbertGobbels/GAwesomeBot"
-                    },
-                    color: 0x9ECDF2,
-					description: `Modlog is currently ${serverDocument.modlog.log_channel ? "enabled" : "disabled"}. 😺 The commands that work with my wonderful modlog feature are: \`ban\`, \`kick\`, \`mute\`, \`reason\`, \`softban\`, \`unban\`, \`unmute\` and \`warn\``
+        			author: {
+            			name: bot.user.username,
+            			icon_url: bot.user.avatarURL,
+            			url: "https://github.com/GilbertGobbels/GAwesomeBot"
+          			},
+          			color: (serverDocument.modlog.isEnabled ? 0x00FF00 : 0xFF0000),
+					description: `Modlog is currently ${serverDocument.modlog.isEnabled ? "enabled" : "disabled"}. 😺 The commands that work with my wonderful modlog feature are: \`ban\`, \`kick\`, \`mute\`, \`reason\`, \`softban\`, \`unban\`, \`unmute\` and \`warn\``
 				}
 			});
 			break;


### PR DESCRIPTION
_credit to my friend, SamSoft_

Setting up modlog is easy. `{prefix}modlog enable #channel`. You can check it using `{prefix}modlog`.

Theres an issue, it wasn't checking for isEnabled. it was checking for an inexistent `log_channel` variable.

Replacing that with isEnabled fixes the issue (also, it goes red if its off, and green if its on.)

Spacing is just Atom 😛 