### PR TITLE
Added commandKey and commandPrefix to cmd extensions

### DIFF
--- a/Modules/ExtensionStructures/Sandbox.js
+++ b/Modules/ExtensionStructures/Sandbox.js
@@ -95,6 +95,8 @@ module.exports = (bot, db, winston, extensionDocument, svr, serverDocument, ch, 
 	}
 	if(extensionDocument.type=="command") {
 		params.commandSuffix = suffix.trim();
+		params.commandPrefix = bot.getCommandPrefix(msg.channel.guild, serverDocument);
+		params.commandKey = extensionDocument.key;
 	}
 	return params;
 };


### PR DESCRIPTION
This simple addition allows a command extension to know its own command key and the command prefix of the guild, so that the extension can provide better error messages or guidance to users.

e.g.
```
channel.createMessage("You did not mention a user. Run `" + commandPrefix + commandKey + " <message> @user`");
```