### PR TITLE
Translation now uses MS Azure Cognitive Services

### DIFF
--- a/Commands/Public/translate.js
+++ b/Commands/Public/translate.js
@@ -9,7 +9,22 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 	const source = suffix.substring(suffix.lastIndexOf(" ")+1);
 	const data = suffix.substring(0, suffix.lastIndexOf(" "));
 
-	if(target && source && data) {
+	if(target && data && source == "?") {
+		mstranslate.detect({text: data}, (err, res) => {
+			if(err) {
+				winston.error(`Failed to detect language for '${data}'`, {svrid: msg.channel.guild.id, chid: msg.channel.id, usrid: msg.author.id}, err);
+			} else {
+				mstranslate.translate({text: data, from: res, to: target}, (err, res) => {
+					if(err) {
+						winston.error(`Failed to translate '${data}'`, {svrid: msg.channel.guild.id, chid: msg.channel.id, usrid: msg.author.id}, err);
+					} else {
+						msg.channel.createMessage(`\`\`\`${res}\`\`\``);
+					}
+				});
+			}
+		});
+	}
+	else if(target && source && data) {
 		mstranslate.translate({text: data, from: source, to: target}, (err, res) => {
 			if(err) {
 				winston.error(`Failed to translate '${data}'`, {svrid: msg.channel.guild.id, chid: msg.channel.id, usrid: msg.author.id}, err);

--- a/Commands/Public/translate.js
+++ b/Commands/Public/translate.js
@@ -1,4 +1,4 @@
-const translate = require("./../../Modules/MicrosoftTranslate.js");
+const mstranslate = require("./../../Modules/MicrosoftTranslate.js");
 
 module.exports = (bot, db, config, winston, userDocument, serverDocument, channelDocument, memberDocument, msg, suffix, commandData) => {
 	const target = suffix.substring(suffix.lastIndexOf(" ")+1);
@@ -7,14 +7,14 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 		suffix = suffix.substring(0, suffix.lastIndexOf(" to"));
 	}
 	const source = suffix.substring(suffix.lastIndexOf(" ")+1);
-	const text = suffix.substring(0, suffix.lastIndexOf(" "));
+	const data = suffix.substring(0, suffix.lastIndexOf(" "));
 
-	if(target && source && text) {
-		translate(text, source, target, (err, res) => {
+	if(target && source && data) {
+		mstranslate.translate({text: data, from: source, to: target}, (err, res) => {
 			if(err) {
-				winston.error(`Failed to translate '${text}'`, {svrid: msg.channel.guild.id, chid: msg.channel.id, usrid: msg.author.id}, err);
+				winston.error(`Failed to translate '${data}'`, {svrid: msg.channel.guild.id, chid: msg.channel.id, usrid: msg.author.id}, err);
 			} else {
-				msg.channel.createMessage(`\`\`\`${res.translated_text}\`\`\``);
+				msg.channel.createMessage(`\`\`\`${res}\`\`\``);
 			}
 		});
 	} else {

--- a/Configuration/auth.json
+++ b/Configuration/auth.json
@@ -11,8 +11,7 @@
 		"google_api_key": "",
 		"google_cse_id": "",
 		"imgur_client_id": "",
-		"microsoft_client_id": "",
-    	"microsoft_client_secret": "",
+		"microsoft_cs_key": "",
     	"twitch_client_id": "",
     	"wolfram_app_id": ""
 	}

--- a/Configuration/commands.json
+++ b/Configuration/commands.json
@@ -798,7 +798,7 @@
             "category": "Utility 🔦"
         },
         "translate": {
-            "usage": "<text> <source lang> to <target lang>",
+            "usage": "<text> <\"?\" or source lang> to <target lang>",
             "description": "Uses Microsoft Translate to translate a word/phrase into another language",
             "defaults": {
                 "is_enabled": true,

--- a/Events/messageCreate.js
+++ b/Events/messageCreate.js
@@ -1,5 +1,5 @@
 const checkFiltered = require("./../Modules/FilterChecker.js");
-const translate = require("./../Modules/MicrosoftTranslate.js");
+const mstranslate = require("./../Modules/MicrosoftTranslate.js");
 const runExtension = require("./../Modules/ExtensionRunner.js");
 
 const levenshtein = require("fast-levenshtein");
@@ -286,14 +286,14 @@ module.exports = (bot, db, config, winston, msg) => {
 
 				// Only keep responding if the bot is on in the channel and author isn't blocked on the server
 				if(channelDocument.bot_enabled && serverDocument.config.blocked.indexOf(msg.author.id)==-1) {
-					// Translate message if neccesary
+					// Translate message if necessary
 					const translatedDocument = serverDocument.config.translated_messages.id(msg.author.id);
 					if(translatedDocument) {
-						translate(msg.cleanContent, translatedDocument.source_language, "EN", (err, res) => {
+						mstranslate.translate({text: msg.cleanContent, from: translatedDocument.source_language, to: "EN"}, (err, res) => {
 							if(err) {
 								winston.error(`Failed to translate message '${msg.cleanContent}' from member '${msg.author.username}' on server '${msg.channel.guild.name}'`, {svrid: msg.channel.guild.id, usrid: msg.author.id}, err);
 							} else {
-								msg.channel.createMessage(`**@${bot.getName(msg.channel.guild, serverDocument, msg.member)}** said:\`\`\`${res.translated_text}\`\`\``, {disable_everyone: true});
+								msg.channel.createMessage(`**@${bot.getName(msg.channel.guild, serverDocument, msg.member)}** said:\`\`\`${res}\`\`\``, {disable_everyone: true});
 							}
 						});
 					}

--- a/Modules/MicrosoftTranslate.js
+++ b/Modules/MicrosoftTranslate.js
@@ -1,6 +1,6 @@
 const auth = require("./../Configuration/auth.json");
+const MsTranslator = require('mstranslator');
 
-module.exports = require("bing-translate").init({
-	client_id: auth.tokens.microsoft_client_id,
-	client_secret: auth.tokens.microsoft_client_secret
-}).translate;
+module.exports = new MsTranslator({
+	api_key: auth.tokens.microsoft_cs_key
+}, true);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     },
     "license": "GPL v2",
     "dependencies": {
-        "bing-translate": "*",
         "body-parser": "*",
         "compression": ">=1.6.0",
         "connect-mongo": ">=1.3.0",
@@ -35,6 +34,7 @@
         "money": "*",
         "mongoose": ">=4.5.0",
         "mongoose-findorcreate": ">=0.1.2",
+        "mstranslator": "*",
         "node-base64-image": ">=1.0.1",
         "object-sizeof": ">=1.0",
         "parse-duration": "*",


### PR DESCRIPTION
Following the retirement of Microsoft DataMarket at the end of March 2017, the translation command and auto-translate feature will no longer work. Additionally, those new to AB/GAB have not been able to register API keys on DataMarket as this was closed in December 2016.

Given that Microsoft provides an excellent translation API for free (with up to 2 million characters per month), it seems sensible to continue using Microsoft (as opposed to other translation APIs).

The translation command and auto-translate feature are both now fully working in GAB, using the new MS Cognitive Services API.

Existing GAB hosters will need to:

1. obtain a Cognitive Services API key (I will post instructions on how to do so below).
2. edit their Configuration/auth.json to specify the new API key (with the new field: `microsoft_cs_key` [the old microsoft_client_id and microsoft_client_secret fields can be removed]).
3. run `npm update` to install the MsTranslator node module.