### PR TITLE
Improved shardInfo messages.

### DIFF
--- a/Events/ready.js
+++ b/Events/ready.js
@@ -1,3 +1,4 @@
+const shardInfo = require("./shardsReady.js");
 const auth = require("./../Configuration/auth.json");
 const getNewServerData = require("./../Modules/NewServer.js");
 const clearStats = require("./../Modules/ClearServerStats.js");
@@ -11,7 +12,8 @@ const postData = require("./../Modules/PostData.js");
 const startWebServer = require("./../Web/WebServer.js");
 
 module.exports = (bot, db, config, winston) => {
-	winston.info("All shards connected");
+	
+	shardInfo(bot, db, config, winston);
 
 	// Count a server's stats (games, clearing, etc.);
 	const statsCollector = () => {

--- a/Events/shardReady.js
+++ b/Events/shardReady.js
@@ -1,4 +1,0 @@
-// A shard receives the ready packet
-module.exports = (bot, db, config, winston, id) => {
-	winston.info(`Shard ${id + 1}/${config.shard_count || 1} connected: ${bot.guilds.size} guilds`);
-};

--- a/Events/shardsReady.js
+++ b/Events/shardsReady.js
@@ -9,6 +9,5 @@ module.exports = (bot, db, config, winston) => {
 	bot.shards.forEach(shard => {
 		winston.info(`Shard ${shard.id + 1}/${config.shard_count || 1} connected: ${guilds[shard.id]} guilds, ${users[shard.id]} users`);
 	});
-
 	winston.info("All shards connected");
 };

--- a/Events/shardsReady.js
+++ b/Events/shardsReady.js
@@ -1,0 +1,14 @@
+// A shard receives the ready packet
+module.exports = (bot, db, config, winston) => {
+	winston.info(`Shards: ${config.shard_count}`);
+	let users = new Array(bot.shards.size).fill(0), guilds = new Array(bot.shards.size).fill(0);
+	bot.guilds.forEach(guild => {
+		users[guild.shard.id] += guild.members.size;
+		guilds[guild.shard.id] += 1;
+	});
+	bot.shards.forEach(shard => {
+		winston.info(`Shard ${shard.id + 1}/${config.shard_count || 1} connected: ${guilds[shard.id]} guilds, ${users[shard.id]} users`);
+	});
+
+	winston.info("All shards connected");
+};

--- a/bot.js
+++ b/bot.js
@@ -1,7 +1,6 @@
 // Import and setup files and modules
 const eventHandlers = {
 	ready: require("./Events/ready.js"),
-	shardReady: require("./Events/shardReady.js"),
 	guildCreate: require("./Events/guildCreate.js"),
 	guildUpdate: require("./Events/guildUpdate.js"),
 	guildDelete: require("./Events/guildDelete.js"),
@@ -46,14 +45,11 @@ database.initialize(config.db_url, err => {
 			winston.info("Started bot application");
 		});
 
-		// After guilds and users have been created (first-time only)
+		/* After guilds and users have been created (first-time only)
+		 * Will also trigger the shard message information
+		 */
 		bot.once("ready", () => {
 			eventHandlers.ready(bot, db, config, winston);
-		});
-
-		// A shard receives the ready packet
-		bot.on("shardReady", id => {
-			eventHandlers.shardReady(bot, db, config, winston, id);
 		});
 
 		// Server joined by bot
@@ -199,16 +195,16 @@ database.initialize(config.db_url, err => {
 			}
 		});
 
-		// Message updated (edited, functionpinned, etc.)
+		// Message edited
 		bot.on("messageUpdate", (msg, oldmsgdata) => {
 			if(bot.isReady) {
-				const messageUpdateDomain = domain.create();
-				messageUpdateDomain.run(() => {
-					eventHandlers.messageUpdate(bot, db, config, winston, msg, oldmsgdata);
-				});
-				messageUpdateDomain.on("error", err => {
-					winston.error(err);
-				});
+					const messageUpdateDomain = domain.create();
+					messageUpdateDomain.run(() => {
+						eventHandlers.messageUpdate(bot, db, config, winston, msg, oldmsgdata);
+					});
+					messageUpdateDomain.on("error", err => {
+						winston.error(err);
+					});
 			}
 		});
 


### PR DESCRIPTION
They will now appear in the READY event, which, while it might make the bot look like its not loading, you'll see the messages decently fast

I've made it this way instead of on shardReady events due to incomplete data. This also caused that bug I mentioned about. Bare-bone example:
```
You have 50 guilds and 2 shards
Shard 1 has 25 guilds
Shard 2 has 50 guilds
```