### PR TITLE
Change wiki link in "Help" To github instead of GAB bot.

### DIFF
--- a/Commands/Public/help.js
+++ b/Commands/Public/help.js
@@ -4,7 +4,7 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
         const getCommandHelp = (name, type, usage, description) => {
         	return {
         		name: `__Help for ${type} command **${name}**__`,
-				value: `${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}Click [here](https://bot.gilbertgobbels.xyz:8008/wiki/Commands#${name}) for more info`,
+				value: `${description ? (`Description: ${description}\n`) : ""}${usage ? (`Usage: \`${usage}\`\n`) : ""}Click [here](https://github.com/GilbertGobbels/GAwesomeBot/wiki/Commands#${name}) for more info`,
 				inline: true
 			};
 		};
@@ -46,7 +46,7 @@ module.exports = (bot, db, config, winston, userDocument, serverDocument, channe
 				description: `${msg.author.mention} Check your PMs.`
 			}
 		});
-		let description = `You can use the following commands in public chat on ${msg.channel.guild.name} with the prefix \`${bot.getCommandPrefix(msg.channel.guild, serverDocument)}\`.\n\tSome commands might not be shown because you don't have permission to use them or they've been disabled by a server admin.\nFor a list of commands you can use in private messages with me, respond to this message with \`help\`. 👌\n\tFor detailed information about each command and all of GAwesomeBot's other features, head over to our wiki [here](https://bot.gilbertgobbels.xyz:8008/wiki/Commands).\n\tIf you need support using GAwesomeBot, please join our Discord server [here](${config.discord_link}). Have fun! 🙂🐬`;
+		let description = `You can use the following commands in public chat on ${msg.channel.guild.name} with the prefix \`${bot.getCommandPrefix(msg.channel.guild, serverDocument)}\`.\n\tSome commands might not be shown because you don't have permission to use them or they've been disabled by a server admin.\nFor a list of commands you can use in private messages with me, respond to this message with \`help\`. 👌\n\tFor detailed information about each command and all of GAwesomeBot's other features, head over to our wiki [here](https://github.com/GilbertGobbels/GAwesomeBot/wiki/Commands).\n\tIf you need support using GAwesomeBot, please join our Discord server [here](${config.discord_link}). Have fun! 🙂🐬`;
 		const commands = {};
 		const memberBotAdmin = bot.getUserBotAdmin(msg.channel.guild, serverDocument, msg.member);
 		bot.getPublicCommandList().forEach(command => {


### PR DESCRIPTION
Because the GAB bot has been down for quite some time and is often slow, I propose we change it to the Github's wiki that we have setup instead.

Sorry if I screwed something up while doing this PR, I barely have used GitHub.

The link changes have been confirmed to work on HuskyBot.