### PR TITLE
Fixed profile_fields key deletion in bot.deleteMemberDataKey()

### DIFF
--- a/Modules/ExtensionStructures/InternalBot.js
+++ b/Modules/ExtensionStructures/InternalBot.js
@@ -105,6 +105,7 @@ module.exports = class Bot {
 					memberDocument.profile_fields = {};
 				}
 				delete memberDocument.profile_fields[key];
+				serverDocument.markModified("members");
 				serverDocument.save(err => {
 					callback(err, memberDocument);
 				});


### PR DESCRIPTION
Profile field key deletion wasn't working because the member document wasn't markModified before save. Easy fix.