### PR TITLE
Ability to DnD in the maintainer console

### DIFF
--- a/Web/views/pages/maintainer-bot-user.ejs
+++ b/Web/views/pages/maintainer-bot-user.ejs
@@ -53,6 +53,7 @@
 											<select name="status">
 												<option value="online"<%= bot_user.status=="online" ? " selected" : "" %>>Online</option>
 												<option value="idle"<%= bot_user.status=="idle" ? " selected" : "" %>>Idle</option>
+												<option value="dnd"<%= bot.user.status=="dnd" ? " selected" : ""%>>Do Not Disturb</option>
 												<option value="offline"<%= bot_user.status=="offline" ? " selected" : "" %>>Invisible</option>
 											</select>
 										</span>

--- a/Web/views/pages/maintainer-bot-user.ejs
+++ b/Web/views/pages/maintainer-bot-user.ejs
@@ -53,7 +53,7 @@
 											<select name="status">
 												<option value="online"<%= bot_user.status=="online" ? " selected" : "" %>>Online</option>
 												<option value="idle"<%= bot_user.status=="idle" ? " selected" : "" %>>Idle</option>
-												<option value="dnd"<%= bot.user.status=="dnd" ? " selected" : ""%>>Do Not Disturb</option>
+												<option value="dnd"<%= bot_user.status=="dnd" ? " selected" : ""%>>Do Not Disturb</option>
 												<option value="offline"<%= bot_user.status=="offline" ? " selected" : "" %>>Invisible</option>
 											</select>
 										</span>


### PR DESCRIPTION
Actually Discord allows bots setting their status to DnD, so why not?