### PR TITLE
Update admin-ongoing-activities.ejs

### DIFF
--- a/Web/views/pages/admin-ongoing-activities.ejs
+++ b/Web/views/pages/admin-ongoing-activities.ejs
@@ -273,7 +273,7 @@
 									<span>Nothing to see here</span>
 								</div>
 								<div class="message-body">
-									There aren't any open lotteries on this server. Start an AwesomePoints lottery with <code><%= commandPrefix %>points lottery</code>.
+									There aren't any open lotteries on this server. Start an AwesomePoints lottery with <code><%= commandPrefix %>lottery start</code>.
 								</div>
 							</article>
 						<% } %>


### PR DESCRIPTION
# What?
This pull request contains fix for Ongoing activities page on Web interface.
# Why?
When typing `<prefix>points lottery` (please replace `<prefix>` with configured one), it will search for users that having name 'lottery', which gives nothing.
Proof _(Tested with HuskyBot, which is nicknamed as 'AwesomeBot')_:
![points lottery thing](https://i.imgur.com/yY15xyb.png)
<!-- I didn' tested that, because mongo 👀. And blame BitQuote... -->