### PR TITLE
Replace all "?svrid=" links with the new inline variant

### DIFF
--- a/Web/public/js/app.js
+++ b/Web/public/js/app.js
@@ -169,7 +169,7 @@ GAwesomeUtil.switchActivityLayout = type => {
 
 GAwesomeUtil.activityBanGuild = svrid => {
 	if (confirm("Are you sure you want to remove this guild from the activity page? It will no longer be visible on this page.")) {
-		$.post("/dashboard/servers/server-list?svrid=maintainer", { removeFromActivity: svrid }).done(() => {
+		$.post("/dashboard/maintainer/servers/server-list", { removeFromActivity: svrid }).done(() => {
 			const cardContent = $(`#cardContent-${svrid}`);
 			GAwesomeData.activity.guildData[svrid] = cardContent.html();
 			cardContent.html(`
@@ -186,7 +186,7 @@ GAwesomeUtil.activityBanGuild = svrid => {
 };
 
 GAwesomeUtil.activityUnbanGuild = svrid => {
-	$.post("/dashboard/servers/server-list?svrid=maintainer", { unbanFromActivity: svrid }).done(() => {
+	$.post("/dashboard/maintainer/servers/server-list", { unbanFromActivity: svrid }).done(() => {
 		const cardContent = $(`#cardContent-${svrid}`);
 		cardContent.removeClass("has-text-centered");
 		cardContent.html(GAwesomeUtil.activity.guildData[svrid]);

--- a/Web/public/js/update.js
+++ b/Web/public/js/update.js
@@ -212,7 +212,7 @@ $(document).ready(function() {
 				state++;
 				break;
 			case 2:
-				const post = () => $.post("/dashboard/management/version?svrid=maintainer", () => {
+				const post = () => $.post("/dashboard/maintainer/management/version", () => {
 					const socket = io('/dashboard/management/version');
 
 					socket.on("update", data => {

--- a/Web/views/pages/admin-admins.ejs
+++ b/Web/views/pages/admin-admins.ejs
@@ -26,7 +26,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-role_id": newAdminRole.val(),
 					"new-level": newAdminLevel.val()
@@ -75,7 +75,7 @@
 							</div>
 						</div>
 					</article>
-					<form id="form" action="<%= currentPage %>?svrid=<%= serverData.id %>" method="post">
+					<form id="form" action="<%= currentPage %>" method="post">
 						<div class="field" style="overflow-x: scroll;">
 							<% if(configData.admins.length>0) { %>
 							<table class="table is-fullwidth">

--- a/Web/views/pages/admin-auto-translation.ejs
+++ b/Web/views/pages/admin-auto-translation.ejs
@@ -26,7 +26,7 @@
 		if(newTranslatedMember.val() && newTranslatedLanguage.val() && Array.prototype.slice.call(document.getElementById("new-translated-enabled_channel_ids").querySelectorAll('input[type="checkbox"]')).some(x => x.checked)) {
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-member": newTranslatedMember.val(),
 					"new-source_language": newTranslatedLanguage.val(),

--- a/Web/views/pages/admin-blocked.ejs
+++ b/Web/views/pages/admin-blocked.ejs
@@ -19,7 +19,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-member": newBlockMember.val()
 				},
@@ -52,7 +52,7 @@
 							</div>
 						</div>
 					</article>
-					<form id="form" action="<%= currentPage %>?svrid=<%= serverData.id %>" method="post">
+					<form id="form" action="<%= currentPage %>" method="post">
 						<div class="field" style="overflow-x: scroll;">
 							<% if(configData.blocked.length>0) { %>
 							<table class="table is-fullwidth">

--- a/Web/views/pages/admin-extensions.ejs
+++ b/Web/views/pages/admin-extensions.ejs
@@ -9,7 +9,7 @@
 	function updateExtensionFromGallery(extid) {
 		$.ajax({
 			type: "POST",
-			url: "/dashboard/other/extensions?svrid=<%= serverData.id %>",
+			url: "<%= currentPage %>",
 			data: {
 				"new-gallery": extid
 			},
@@ -45,7 +45,7 @@
 					</div>
 					<br>
 					<div class="container">
-						<form id="form" action="<%= currentPage %>?svrid=<%= serverData.id %>" method="post">
+						<form id="form" action="<%= currentPage %>" method="post">
 							<div style="overflow-x: scroll;">
 								<% if(configData.extensions.length>0) { %>
 									<table class="table">
@@ -80,7 +80,7 @@
 														<%= configData.extensions[i].store %> KB
 													</td>
 													<td>
-														<a class="button is-small is-primary" href="/dashboard/other/extension-builder?svrid=<%= serverData.id %>&extid=<%= configData.extensions[i]._id %>">
+														<a class="button is-small is-primary" href="/dashboard/<%= serverData.id %>/other/extension-builder?extid=<%= configData.extensions[i]._id %>">
 															<span class="icon is-small">
 																<i class="fa fa-pencil"></i>
 															</span>
@@ -106,14 +106,14 @@
 											<span>Nothing to see here</span>
 										</div>
 										<div class="message-body">
-											You haven't created any extensions yet. Head over to the <a href="/dashboard/other/extension-builder?svrid=<%= serverData.id %>">extension builder</a> to get started building one!
+											You haven't created any extensions yet. Head over to the <a href="/dashboard/<%= serverData.id %>/other/extension-builder">extension builder</a> to get started building one!
 										</div>
 									</article>
 									<br>
 								<% } %>
 							</div>
 							<div class="control is-horizontal is-grouped">
-								<a class="button" href="/dashboard/other/extension-builder?svrid=<%= serverData.id %>">
+								<a class="button" href="/dashboard/<%= serverData.id %>/other/extension-builder">
 									<span class="icon">
 								        <i class="fa fa-code"></i>
 								    </span>

--- a/Web/views/pages/admin-muted.ejs
+++ b/Web/views/pages/admin-muted.ejs
@@ -23,7 +23,7 @@
 		if(newMutedMember.val()) {
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-member": newMutedMember.val(),
 					"new-channel_id": newMutedChannel.val()

--- a/Web/views/pages/admin-ongoing-activities.ejs
+++ b/Web/views/pages/admin-ongoing-activities.ejs
@@ -12,7 +12,7 @@
 	  	$(`#endSession-${type}-${id}`).html("Ending Game...");
 		$.ajax({
 			type: "POST",
-			url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+			url: "<%= currentPage %>",
 			data: {
 				"end-type": type,
 				"end-id": id

--- a/Web/views/pages/admin-public-data.ejs
+++ b/Web/views/pages/admin-public-data.ejs
@@ -7,7 +7,7 @@
 	<script>
 		function unbanGuild(svrid) {
 			$("#unbanGuild").addClass("is-loading");
-			$.post("/dashboard/servers/server-list?svrid=maintainer", { unbanFromActivity: svrid }).done(() => {
+			$.post("/dashboard/maintainer/servers/server-list", { unbanFromActivity: svrid }).done(() => {
 				$(`#unbanGuild`).removeClass("is-loading").html("<span class='icon'><i class='fa fa-check'></i></span> &nbsp; Unbanned");
 			});
 		}

--- a/Web/views/pages/admin-ranks.ejs
+++ b/Web/views/pages/admin-ranks.ejs
@@ -24,7 +24,7 @@
 		if(newRankName.val() && newRankScore.val()) {
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-name": newRankName.val(),
 					"new-max_score": newRankScore.val(),

--- a/Web/views/pages/admin-rss-feeds.ejs
+++ b/Web/views/pages/admin-rss-feeds.ejs
@@ -25,7 +25,7 @@
 		  hide_update_modal = true;
 		  $.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-url": newRssUrl.val(),
 					"new-name": newRssName.val().toLowerCase()

--- a/Web/views/pages/admin-stats-collection.ejs
+++ b/Web/views/pages/admin-stats-collection.ejs
@@ -22,7 +22,7 @@
 					</h1>
 					<article class="message is-primary">
 						<div class="message-body">
-							GAwesomeBot constantly records information about <strong>message, voice, and game activity</strong> on your server. You can view this data in the <code>stats</code> command, on the <a href="/dashboard/overview?svrid=<%= serverData.id %>">overview page</a>, and more.
+							GAwesomeBot constantly records information about <strong>message, voice, and game activity</strong> on your server. You can view this data in the <code>stats</code> command, on the <a href="/dashboard/<%= serverData.id %>/overview">overview page</a>, and more.
 						</div>
 					</article>
 					<form id="form" onsubmit="submitForm(); return false;">

--- a/Web/views/pages/admin-status-messages.ejs
+++ b/Web/views/pages/admin-status-messages.ejs
@@ -22,7 +22,7 @@
 					data[newMessageId] = newMessage.val()
 					$.ajax({
 						type: 'POST',
-						url: '<%= currentPage %>?svrid=<%= serverData.id %>',
+						url: '<%= currentPage %>',
 						data: data,
 						success: function () {
 							saveFormState()
@@ -41,7 +41,7 @@
 					toSend[data] = 'on'
 					$.ajax({
 						type: 'POST',
-						url: '<%= currentPage %>?svrid=<%= serverData.id %>',
+						url: '<%= currentPage %>',
 						data: toSend,
 						success: function () {
 							messageNode.remove()

--- a/Web/views/pages/admin-streamers.ejs
+++ b/Web/views/pages/admin-streamers.ejs
@@ -19,7 +19,7 @@
 		  hide_update_modal = true;
 		  $.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-name": newStreamerName.val(),
 					"new-type": newStreamerType.val()

--- a/Web/views/pages/admin-strikes.ejs
+++ b/Web/views/pages/admin-strikes.ejs
@@ -28,7 +28,7 @@
 		if((member || newStrikeMember.val()) && newStrikeReason.val()) {
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-member": member || newStrikeMember.val(),
 					"new-reason": newStrikeReason.val()
@@ -50,7 +50,7 @@
 			const parts = strike.id.split("-");
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: send,
 				success: function() {
 					const docs = document.getElementsByClassName('strikes-' + parts[1]);

--- a/Web/views/pages/admin-tag-reaction.ejs
+++ b/Web/views/pages/admin-tag-reaction.ejs
@@ -17,7 +17,7 @@
 		if(newReactionMessage.val()) {
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>",
 				data: {
 					"new-message": newReactionMessage.val()
 				},

--- a/Web/views/pages/admin-tags.ejs
+++ b/Web/views/pages/admin-tags.ejs
@@ -26,7 +26,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+				url: "<%= currentPage %>=",
 				data: {
 					"new-name": newTagName.val(),
 					"new-type": newTagType.val(),

--- a/Web/views/pages/admin-trivia-sets.ejs
+++ b/Web/views/pages/admin-trivia-sets.ejs
@@ -26,7 +26,7 @@
 	        reader.onload = function(event) {
 	            $.ajax({
 					type: "POST",
-					url: "<%= currentPage %>?svrid=<%= serverData.id %>",
+					url: "<%= currentPage %>",
 					data: {
 						"new-name": newTriviaName.val(),
 						"new-items": event.target.result,
@@ -83,7 +83,7 @@
 													<%= configData.trivia_sets[i].items.length %>
 												</td>
 												<td>
-													<a class="button is-small" href="<%= currentPage %>?svrid=<%= serverData.id %>&i=<%= i %>" target="_blank" download="<%= configData.trivia_sets[i]._id %>.json">
+													<a class="button is-small" href="<%= currentPage %>?i=<%= i %>" target="_blank" download="<%= configData.trivia_sets[i]._id %>.json">
 														<span>Download</span>
 														<span class="icon is-small">
 															<i class="fa fa-download"></i>

--- a/Web/views/pages/maintainer-blocklist.ejs
+++ b/Web/views/pages/maintainer-blocklist.ejs
@@ -16,7 +16,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=maintainer",
+				url: "<%= currentPage %>",
 				data: {
 					"new-user": newBlockUser.val()
 				},
@@ -49,7 +49,7 @@
 							</div>
 						</div>
 					</article>
-					<form id="form" action="<%= currentPage %>?svrid=maintainer" method="post">
+					<form id="form" action="<%= currentPage %>=" method="post">
 						<div class="field" style="overflow-x: scroll;">
 							<% if(config.global_blocklist.length>0) { %>
 							<table class="table is-fullwidth">

--- a/Web/views/pages/maintainer-eval.ejs
+++ b/Web/views/pages/maintainer-eval.ejs
@@ -47,7 +47,7 @@
 
         	if (code) {
         		codeArea.removeClass("is-danger");
-        		$.post("/dashboard/management/eval?svrid=maintainer", { code, target })
+        		$.post("/dashboard/maintainer/management/eval", { code, target })
                   .done(data => {
                   	data = JSON.parse(data);
                   	let log = evalLog.replace("$CODE$", code)

--- a/Web/views/pages/maintainer-maintainers.ejs
+++ b/Web/views/pages/maintainer-maintainers.ejs
@@ -20,7 +20,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=maintainer",
+				url: "<%= currentPage %>",
 				data: {
 				  "new-user": newMaintainerUser.val(),
 				  "isSudo": $("#role-select").val() === "sudo",

--- a/Web/views/pages/maintainer-shards.ejs
+++ b/Web/views/pages/maintainer-shards.ejs
@@ -16,7 +16,7 @@
             if (isPerformingAction || !res) return;
             isPerformingAction = true;
             $("#shutdown").html("<span class=\"icon\"><i class=\"fa fa-power-off\"></i></span>Shutting down...");
-            $.post("/dashboard/management/shards?svrid=maintainer", { shutdown: "master" }).done(() => {
+            $.post("/dashboard/maintainer/management/shards", { shutdown: "master" }).done(() => {
               $("#shutdown").html("<span class=\"icon\"><i class=\"fa fa-power-off\"></i></span>Shutting down... Goodbye!");
               swal.stopLoading();
               swal("Success!", "You will be redirected shortly.", "success");
@@ -36,7 +36,7 @@
         	    if (isPerformingAction || !res) return;
         	    isPerformingAction = true;
                 $("#restart").html("<span class=\"icon\"><i class=\"fa fa-refresh\"></i></span>Restarting...");
-        		$.post("/dashboard/management/shards?svrid=maintainer", { restart: "master" }).done(() => {
+        		$.post("/dashboard/maintainer/management/shards", { restart: "master" }).done(() => {
         			$("#restart").html("<span class=\"icon\"><i class=\"fa fa-refresh\"></i></span>Restarting... Be right back!");
         			swal.stopLoading();
         			swal("Success!", "You will be redirected shortly.", "success");
@@ -56,7 +56,7 @@
         	    if (isPerformingAction || !res) return;
                 isPerformingAction = true;
                 $(`#freeze-${id}`).html("Freezing...");
-                $.post("/dashboard/management/shards?svrid=maintainer", { "freeze-shard": id }).done(() => {
+                $.post("/dashboard/maintainer/management/shards", { "freeze-shard": id }).done(() => {
                 	$(`#freeze-${id}`).parent().html(`<a id="restart-${id}" class="card-footer-item card-footer-item-danger" href="javascript:restartShard(${id})">Restart</a>`);
                 	$(`#shard-header-${id}`).append(" (Frozen)");
                 	swal.stopLoading();
@@ -76,7 +76,7 @@
                 if (isPerformingAction || !res) return;
                 isPerformingAction = true;
                 $(`#reset-${id}`).html("Resetting...");
-                $.post("/dashboard/management/shards?svrid=maintainer", { "reset-shard": id }).done(() => {
+                $.post("/dashboard/maintainer/management/shards", { "reset-shard": id }).done(() => {
                 	$(`#reset-${id}`).html("Reset");
                 	swal("Success!", "This shard is now being reinitialized.", "success");
                 	isPerformingAction = false;
@@ -94,7 +94,7 @@
                 if (isPerformingAction || !res) return;
                 isPerformingAction = true;
                 $(`#restart-${id}`).html("Restarting...");
-                $.post("/dashboard/management/shards?svrid=maintainer", { "restart-shard": id }).done(() => {
+                $.post("/dashboard/maintainer/management/shards", { "restart-shard": id }).done(() => {
                 	$(`#restart-${id}`).parent().html(`<div class="card-footer-item" style="cursor: default; user-select: none;">See you soon!</div>`);
                 	swal.stopLoading();
                 	swal("Success!", "This shard is now restarting.", "success");
@@ -104,7 +104,7 @@
         }
 
         function dismissWarning(warn, id) {
-        	$.post("/dashboard/management/shards?svrid=maintainer", { dismiss: warn }).done(() => {
+        	$.post("/dashboard/maintainer/management/shards", { dismiss: warn }).done(() => {
         		$(`#warning-${id}`).remove();
         		let warnCounter = $("#warning-count");
         		warnCounter.text(Number(warnCounter.text()) - 1);

--- a/Web/views/pages/maintainer-wiki-contributors.ejs
+++ b/Web/views/pages/maintainer-wiki-contributors.ejs
@@ -19,7 +19,7 @@
 			hide_update_modal = true;
 			$.ajax({
 				type: "POST",
-				url: "<%= currentPage %>?svrid=maintainer",
+				url: "<%= currentPage %>",
 				data: {
 					"new-user": newContributorUser.val()
 				},
@@ -52,7 +52,7 @@
 							</div>
 						</div>
 					</article>
-					<form id="form" action="<%= currentPage %>?svrid=maintainer" method="post">
+					<form id="form" action="<%= currentPage %>" method="post">
 						<div class="field" style="overflow-x: scroll;">
 							<% if(config.wiki_contributors.length>0) { %>
 									<table class="table is-fullwidth">

--- a/Web/views/pages/maintainer.ejs
+++ b/Web/views/pages/maintainer.ejs
@@ -68,7 +68,7 @@
 							</a>
 						</div>
 						<div class="column">
-							<a class="box notification is-white" href="/dashboard/management/shards?svrid=maintainer">
+							<a class="box notification is-white" href="/dashboard/maintainer/management/shards">
 								<div class="heading">
 									<span class="icon is-small">
 										<i class="fa fa-puzzle-piece"></i>
@@ -90,7 +90,7 @@
 							</a>
 						</div>
 						<div class="column">
-							<a class="box notification <% if (disabled) { %>is-dark<% } else if (!utd) { %>is-info<% } else { %>is-white<% } %>"<% if (serverData.accessManagement) { %> href="/dashboard/management/version?svrid=maintainer"<% } %>>
+							<a class="box notification <% if (disabled) { %>is-dark<% } else if (!utd) { %>is-info<% } else { %>is-white<% } %>"<% if (serverData.accessManagement) { %> href="/dashboard/maintainer/management/version"<% } %>>
 								<div class="heading">
 									<span class="icon is-small">
 										<i class="fa fa-code-fork"></i>

--- a/Web/views/partials/extension-builder.ejs
+++ b/Web/views/partials/extension-builder.ejs
@@ -1,4 +1,4 @@
-<form id="form" onsubmit="GAwesomeUtil.saveExtension(<%= isGallery %>, '<%- isGallery ? "/extensions/builder?" : currentPage + "?svrid=" + serverData.id + "&" %><%= extensionData._id ? ('extid=' + extensionData._id) : "" %>'); return false;">
+<form id="form" onsubmit="GAwesomeUtil.saveExtension(<%= isGallery %>, '<%- isGallery ? "/extensions/builder?" : currentPage + "?" %><%= extensionData._id ? ('extid=' + extensionData._id) : "" %>'); return false;">
 	<div class="field">
 		<label class="label">Name</label>
 		<p class="control">


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the stop buttons not doing anything due to a 404 (path `dashboard/xyz/other/ongoing-activities?svrid=xyz` now redirects to `dashboard/xyz/xyz/other/ongoing-activities` which obvioulsy 404s).
**UPDATE**: See title essentially. The same bug as described above also occurred on many other pages so I just updated everything to the new schema,

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [x] This PR modifies Web processing and/or content
  - [x] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
