### PR TITLE
Fix emoji command with line breaks

### DIFF
--- a/Commands/Public/emoji.js
+++ b/Commands/Public/emoji.js
@@ -24,7 +24,8 @@ module.exports = async ({ Constants: { Colors, Text } }, documents, msg, command
 				},
 			},
 		});
-		const animated = msg.suffix.trim().split(/\s+/).trimAll();
+		const suffixNoNewline = msg.suffix.replace(/[\r\n]/g, " ");
+		const animated = suffixNoNewline.trim().split(/\s+/).trimAll();
 		let every = true;
 		for (const param of animated) {
 			const parsed = DJSUtil.parseEmoji(param);
@@ -87,7 +88,7 @@ module.exports = async ({ Constants: { Colors, Text } }, documents, msg, command
 			}
 		} else {
 			try {
-				const b = await Emoji(msg.suffix);
+				const b = await Emoji(suffixNoNewline);
 				if (b) {
 					await m.delete();
 					try {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Emoji command breaks when no space is provided before a line break: https://i.imgur.com/08nMDBI.png (top: without space, bottom with)

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [x] This PR modifies commands
  - [x] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
