### PR TITLE
Fix "invisible" status not working on maintainer bot user page

### DIFF
--- a/Web/views/pages/maintainer-bot-user.ejs
+++ b/Web/views/pages/maintainer-bot-user.ejs
@@ -59,7 +59,7 @@
 												<option value="online"<%= configData.status=="online" ? " selected" : "" %>>Online</option>
 												<option value="idle"<%= configData.status=="idle" ? " selected" : "" %>>Idle</option>
 												<option value="dnd"<%= configData.status=="dnd" ? " selected" : ""%>>Do Not Disturb</option>
-												<option value="offline"<%= configData.status=="offline" ? " selected" : "" %>>Invisible</option>
+												<option value="invisible"<%= configData.status=="invisible" ? " selected" : "" %>>Invisible</option>
 											</select>
 										</span>
 										<span class="help">The availability status of the bot, shown in the colored bubble next to the avatar.</span>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously it set the status to "offline" which doesn't work for the logged in user, it has to be "invisible" and it appears as "offline" only for other users. Discord.JS doesn't complain about wrong values and happily accepted "offline" although it didn't work.

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [x] This PR modifies Web processing and/or content
  - [x] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
