### PR TITLE
Add option to set activity type on bot user maintainer page

### DIFF
--- a/Configurations/config.json
+++ b/Configurations/config.json
@@ -1,25 +1,26 @@
 {
-    "sudoMaintainers": [],
-    "maintainers": [],
-    "wikiContributors": [],
-    "userBlocklist": [],
-    "guildBlocklist": [],
-    "activityBlocklist": [],
-    "activity": {
-        "name": "default",
-        "twitchURL": ""
-    },
-    "status": "online",
-    "headerImage": "header-bg.jpg",
-    "homepageMessageHTML": "",
-    "pmForward": false,
-    "version": "4.1.0",
-    "branch": "development",
-    "perms": {
-        "eval": 0,
-        "sudo": 2,
-        "management": 2,
-        "administration": 1,
-        "shutdown": 2
-    }
+  "sudoMaintainers": [],
+  "maintainers": [],
+  "wikiContributors": [],
+  "userBlocklist": [],
+  "guildBlocklist": [],
+  "activityBlocklist": [],
+  "activity": {
+    "name": "default",
+    "type": "PLAYING",
+    "twitchURL": ""
+  },
+  "status": "online",
+  "headerImage": "header-bg.jpg",
+  "homepageMessageHTML": "",
+  "pmForward": false,
+  "version": "4.1.0",
+  "branch": "development",
+  "perms": {
+    "eval": 0,
+    "sudo": 2,
+    "management": 2,
+    "administration": 1,
+    "shutdown": 2
+  }
 }

--- a/GAwesomeBot.js
+++ b/GAwesomeBot.js
@@ -216,7 +216,8 @@ client.IPC.on("updateBotUser", async msg => {
 	let activity = {};
 	if (!payload.game || payload.game === "gawesomebot.com") activity.name = "https://gawesomebot.com | Shard {shard}".format({ shard: client.shardID });
 	else activity.name = payload.game.format({ shard: client.shardID, totalShards: client.shard.count });
-	activity.type = "PLAYING";
+	activity.type = payload.type || "PLAYING";
+	activity.url = payload.type === "STREAMING" ? payload.twitchURL : null;
 	client.user.setPresence({
 		status: payload.status || "online",
 		activity: activity,

--- a/Internals/Events/ready/GAB.Ready.js
+++ b/Internals/Events/ready/GAB.Ready.js
@@ -101,8 +101,8 @@ class Ready extends BaseEvent {
 		winston.debug("Setting bots playing activity.");
 		let activity = {
 			name: configJSON.activity.name.format({ shard: this.client.shardID, totalShards: this.client.shard.count }),
+			type: configJSON.activity.type,
 			url: configJSON.activity.twitchURL || null,
-			type: configJSON.activity.twitchURL !== "" ? "WATCHING" : "PLAYING",
 		};
 		if (configJSON.activity.name === "default") {
 			activity = {

--- a/Web/controllers/maintainer.js
+++ b/Web/controllers/maintainer.js
@@ -165,14 +165,25 @@ controllers.options.blocklist.post = async (req, res) => {
 controllers.options.bot = async (req, { res }) => {
 	res.setConfigData({
 		status: configJSON.status,
+		type: configJSON.activity.type,
 		game: configJSON.activity.name,
 		game_default: configJSON.activity.name === "default",
-		avatar: req.app.client.user.avatarURL(),
+		twitchURL: configJSON.activity.twitchURL,
+		avatar: req.app.client.user.avatarURL({ type: "png", size: 512 }),
 	}).setPageData("page", "maintainer-bot-user.ejs").render();
 };
 controllers.options.bot.post = async (req, res) => {
-	req.app.client.IPC.send("updateBotUser", { avatar: req.body.avatar, username: req.body.username, game: req.body.game, status: req.body.status });
+	req.app.client.IPC.send("updateBotUser", {
+		avatar: req.body.avatar,
+		username: req.body.username,
+		game: req.body.game,
+		status: req.body.status,
+		type: req.body.type,
+		twitchURL: req.body.twitch,
+	});
 	configJSON.activity.name = req.body.game;
+	configJSON.activity.type = req.body.type;
+	configJSON.activity.twitchURL = req.body.twitch;
 	if (req.body.game === "gawesomebot.com") {
 		configJSON.activity.name = "default";
 	}

--- a/Web/views/pages/maintainer-bot-user.ejs
+++ b/Web/views/pages/maintainer-bot-user.ejs
@@ -66,21 +66,49 @@
 									</div>
 								</div>
 								<div class="field">
-									<label class="label">Game</label>
-									<div class="field has-addons" style="margin-bottom: 0px;">
-										<div class="control has-icons-left is-expanded">
-											<input name="game" id="user-game" class="input is-primary" type="text" value="<%= configData.game === "default" ? "gawesomebot.com" : configData.game %>" style="width: 100%;">
-											<span class="icon"><i class="fa fa-gamepad"></i></span>
+									<div class="columns">
+										<div class="column is-one-third">
+											<label class="label">Type</label>
+											<div class="control">
+												<span class="select is-primary">
+													<select id="user-type" name="type" onchange="if(this.value==='STREAMING') $('#twitch-url-container').removeClass('is-hidden'); else $('#twitch-url-container').addClass('is-hidden');">
+														<option value="PLAYING"<%= configData.type=="PLAYING" ? " selected" : "" %>>Playing</option>
+														<option value="STREAMING"<%= configData.type=="STREAMING" ? " selected" : "" %>>Streaming</option>
+														<option value="LISTENING"<%= configData.type=="LISTENING" ? " selected" : ""%>>Listening to</option>
+														<option value="WATCHING"<%= configData.type=="WATCHING" ? " selected" : "" %>>Watching</option>
+													</select>
+												</span>
+												<span class="help">Appears in front of the game's name.</span>
+											</div>
 										</div>
-										<div class="control">
-                                        	<% if(!configData.game_default) { %>
-												<a name="game-default" class="button" onclick="$('#user-game').val('gawesomebot.com')">
-													Default
-												</a>
-											<% } %>
+	 									<div class="column">
+											<label class="label">Game</label>
+											<div class="field<%= !configData.game_default ? " has-addons" : ""%>" style="margin-bottom: 0px;">
+												<div class="control has-icons-left is-expanded">
+													<input name="game" id="user-game" class="input is-primary" type="text" value="<%= configData.game === "default" ? "gawesomebot.com" : configData.game %>" style="width: 100%;">
+													<span class="icon"><i class="fa fa-gamepad"></i></span>
+												</div>
+												<div class="control">
+        		                                	<% if(!configData.game_default) { %>
+														<a name="game-default" class="button" onclick="$('#user-game').val('gawesomebot.com');$('#user-type').val('PLAYING')">
+															Default
+														</a>
+													<% } %>
+												</div>
+											</div>
+											<span class="help">The game the bot appears to be playing, shown under the username.</span>
 										</div>
 									</div>
-									<span class="help">The game the bot appears to be playing, shown under the username.</span>
+								</div>
+								<div id="twitch-url-container" class="field<%= configData.type!=="STREAMING" ? " is-hidden" : "" %>">
+									<label class="label">Twitch URL</label>
+									<div class="field" style="margin-bottom: 0px;">
+										<div class="control has-icons-left is-expanded">
+											<input name="twitch" id="user-twitch" class="input is-primary" type="text" value="<%= configData.twitchURL %>" style="width: 100%;">
+											<span class="icon"><i class="fa fa-twitch"></i></span>
+										</div>
+									</div>
+									<span class="help">The URL to a twitch channel that will be linked on the bot's profile. Required to set the bot's status to "Streaming".</span>
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Now you can set the activity type ("Playing", "Streaming", "Listening to", "Watching") on the bot user management page as well. When the Streaming type is selected an input field for the Twitch channel URL appears.

Configuration/config.json now is indented with only 2 spaces because that's how it is saved by the bot when it updates.

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [x] This PR modifies Web processing and/or content
  - [x] This PR modifies static/ejs content
  - [x] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
