### PR TITLE
Add more precise duration to year command

### DIFF
--- a/Commands/Public/year.js
+++ b/Commands/Public/year.js
@@ -1,15 +1,23 @@
 const moment = require("moment");
 
 module.exports = async ({ Constants: { Colors } }, documents, msg, commandData) => {
-	const now = new Date;
+	const now = new Date();
 	const next = new Date(now);
 	next.setFullYear(now.getFullYear() + 1);
 	next.setHours(0, 0, 0, 0);
 	next.setMonth(0, 1);
+	const duration = next - now;
+	const seconds = Math.floor((duration / 1000) % 60);
+	const minutes = Math.floor((duration / 1000 / 60) % 60);
+	const hours = Math.floor((duration / (1000 * 60 * 60)) % 24);
+	const days = Math.floor(duration / (1000 * 60 * 60 * 24));
 	return msg.send({
 		embed: {
 			color: Colors.INFO,
-			description: `There are **${moment.duration(next - now).humanize()}** until **${next.getFullYear()}**! 🎆`,
+			description: `There are **${days} days**, **${hours} hours**, **${minutes} minutes** and **${seconds} seconds** until **${next.getFullYear()}**! 🎆`,
+			footer: {
+				text: `Or, in short, ${moment.duration(next - now).humanize()}.`,
+			},
 		},
 	});
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Now with days, hours, minutes and seconds instead of just "8 months".

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [x] This PR modifies commands
  - [x] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
