### PR TITLE
Fix winston throwing a circular JSON error logging on e.g. Snekfetch errors

### DIFF
--- a/Internals/Console.js
+++ b/Internals/Console.js
@@ -1,4 +1,5 @@
 const winston = require("winston");
+const circularJson = require("circular-json");
 const chalk = require("chalk");
 const moment = require("moment");
 require("winston-daily-rotate-file");
@@ -60,6 +61,7 @@ module.exports = class Console {
 				new winston.transports.File({
 					level: config.fileLevel,
 					json: true,
+					stringify: circularJson.stringify,
 					colorize: false,
 					filename: require("path").join(process.cwd(), `logs/verbose.gawesomebot.log`),
 				}),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When logging stuff to the JSON log file winston shoves the output throuh JSON.stringify by default. The problem with this is that errors thrown by for example Snekfetch contain circular references. The error contains the response object which contains the request object which contains the response again. So in the end logging such an error throws an error itself.
Fix that by using circular-json#stringify instead of the default one.

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
