### PR TITLE
Rework paginated embed

### DIFF
--- a/Commands/Private/poll.js
+++ b/Commands/Private/poll.js
@@ -151,11 +151,13 @@ module.exports = {
 								author: {
 									id: usr.id,
 								},
-							}, options, {
+							}, {
 								footer: `You have 4 minute to respond using the number matched to the options shown above.`,
 								title: `There's a poll in #${ch.name} called "__${channelDocument.poll.title}__" ⚔`,
 								description: `To vote anonymously, please select one of the following options.\n**Note** You may need to remove and re-add your reaction for page changes!\n\n{description}`,
 								color: Colors.INFO,
+							}, {
+								descriptions: options,
 							});
 							await initMsg.delete();
 							await menu.init();
@@ -229,20 +231,22 @@ module.exports = {
 						`\t**${option}**`,
 					].join("\n"));
 					map = map.chunk(10);
-					const description = [];
+					const descriptions = [];
 					for (const innerArray of map) {
-						description.push(innerArray.join("\n"));
+						descriptions.push(innerArray.join("\n"));
 					}
 					const menu = new PaginatedEmbed({
 						channel: initMsg.channel,
 						author: {
 							id: usr.id,
 						},
-					}, description, {
+					}, {
 						title: `🍻 Poll named "__${title}__" has started!`,
 						color: Colors.SUCCESS,
 						description: `Check out #${ch.name} (${ch}) to see your poll in action!\nHere are the polls options:\n\n{description}`,
 						footer: ``,
+					}, {
+						descriptions,
 					});
 					await menu.init();
 					await serverDocument.save();

--- a/Commands/Public/catfact.js
+++ b/Commands/Public/catfact.js
@@ -1,5 +1,5 @@
 const { get } = require("snekfetch");
-const PaginatedMenu = require("../../Modules/MessageUtils/PaginatedEmbed");
+const PaginatedEmbed = require("../../Modules/MessageUtils/PaginatedEmbed");
 
 module.exports = async ({ Constants: { Colors, Text, APIs } }, { serverDocument }, msg, commandData) => {
 	let number = msg.suffix;
@@ -10,14 +10,16 @@ module.exports = async ({ Constants: { Colors, Text, APIs } }, { serverDocument 
 
 	const { body, statusCode, statusText } = await get(APIs.CATFACT(number));
 	if (statusCode === 200 && body && body.data.length) {
-		const facts = [];
+		const descriptions = [];
 		body.data.forEach(d => {
-			facts.push(d.fact);
+			descriptions.push(d.fact);
 		});
-		const menu = new PaginatedMenu(msg, facts, {
+		const menu = new PaginatedEmbed(msg, {
 			color: Colors.RESPONSE,
-			title: `Cat fact {current description} out of {total descriptions}`,
+			title: `Cat fact {currentPage} out of {totalPages}`,
 			footer: ``,
+		}, {
+			descriptions,
 		});
 		await menu.init();
 	} else {

--- a/Commands/Public/count.js
+++ b/Commands/Public/count.js
@@ -118,14 +118,15 @@ module.exports = async ({ configJS, Constants: { Colors, Text } }, { serverDocum
 					`\tCurrently at **${countDocument.value}** 📊`,
 				].join("\n");
 			}).chunk(10);
-			const description = [];
+			const descriptions = [];
 			for (const chunk of chunks) {
-				description.push(chunk.join("\n\n"));
+				descriptions.push(chunk.join("\n\n"));
 			}
-			const menu = new PaginatedEmbed(msg, description, {
+			const menu = new PaginatedEmbed(msg, {
 				title: `There ${info.length === 1 ? "is" : "are"} ${info.length} count${info.length === 1 ? "" : "s"} on "${msg.guild}" 📋`,
 				color: Colors.INFO,
-				footer: `Page {current description} out of {total descriptions}`,
+			}, {
+				descriptions,
 			});
 			await menu.init();
 		} else {

--- a/Commands/Public/countdown.js
+++ b/Commands/Public/countdown.js
@@ -76,12 +76,13 @@ module.exports = async ({ client, Constants: { Colors, Text } }, { serverDocumen
 				`\tExpires **${moment(countdown.expiry_timestamp).fromNow()}**`,
 			].join("\n"));
 			const chunks = arr.chunk(10);
-			const description = [];
-			for (const chunk of chunks) description.push(chunk.join("\n\n"));
-			new PaginatedEmbed(msg, description, {
+			const descriptions = [];
+			for (const chunk of chunks) descriptions.push(chunk.join("\n\n"));
+			await new PaginatedEmbed(msg, {
 				title: `There ${arr.length === 1 ? "is" : "are"} ${arr.length} countdown${arr.length === 1 ? "" : "s"} on "${msg.guild}" 🎆`,
 				color: Colors.INFO,
-				footer: `Page {current description} out of {total descriptions}`,
+			}, {
+				descriptions,
 			}).init();
 		} else {
 			msg.send({

--- a/Commands/Public/dogfact.js
+++ b/Commands/Public/dogfact.js
@@ -1,5 +1,5 @@
 const { get } = require("snekfetch");
-const PaginatedMenu = require("../../Modules/MessageUtils/PaginatedEmbed");
+const PaginatedEmbed = require("../../Modules/MessageUtils/PaginatedEmbed");
 
 module.exports = async ({ Constants: { Colors, Text, APIs } }, { serverDocument }, msg, commandData) => {
 	let number = msg.suffix;
@@ -10,14 +10,16 @@ module.exports = async ({ Constants: { Colors, Text, APIs } }, { serverDocument 
 
 	const { body, statusCode, statusText } = await get(APIs.DOGFACT(number));
 	if (statusCode === 200 && body && body.facts.length) {
-		const facts = [];
+		const descriptions = [];
 		body.facts.forEach(d => {
-			facts.push(d);
+			descriptions.push(d);
 		});
-		const menu = new PaginatedMenu(msg, facts, {
+		const menu = new PaginatedEmbed(msg, {
 			color: Colors.RESPONSE,
-			title: `Dog fact {current description} out of {total descriptions}`,
+			title: `Dog fact {currentPage} out of {totalPages}`,
 			footer: ``,
+		}, {
+			descriptions,
 		});
 		await menu.init();
 	} else {

--- a/Commands/Public/e621.js
+++ b/Commands/Public/e621.js
@@ -63,10 +63,14 @@ module.exports = async ({ Constants: { Colors, NSFWEmbed, Text, APIs } }, { serv
 					images.push(`${unparsed[i].file_url}`);
 					descriptions.push(tempDesc.join("\n"));
 				}
-				const menu = new PaginatedEmbed(msg, descriptions, {
+				const menu = new PaginatedEmbed(msg, {
 					color: Colors.RESPONSE,
-					footer: `Result {current description} out of {total descriptions} results`,
-				}, images, fields);
+					footer: `Result {currentPage} out of {totalPages} results`,
+				}, {
+					descriptions,
+					fields,
+					images,
+				});
 				await m.delete();
 				await menu.init();
 			} else {

--- a/Commands/Public/poll.js
+++ b/Commands/Public/poll.js
@@ -58,15 +58,17 @@ module.exports = async ({ Constants: { Colors } }, { serverDocument, channelDocu
 				].join("\n"));
 			});
 			map = map.chunk(10);
-			const options = [];
+			const descriptions = [];
 			for (const innerArray of map) {
-				options.push(innerArray.join("\n"));
+				descriptions.push(innerArray.join("\n"));
 			}
-			const menu = new PaginatedEmbed(msg, options, {
+			const menu = new PaginatedEmbed(msg, {
 				footer: `So far, the winner is "${results.winner || "nobody!"}" They have the most votes out of ${channelDocument.poll.responses.length} total vote${channelDocument.poll.responses.length === 1 ? "" : "s"} ✅`,
 				color: Colors.INFO,
 				title: `🔮 Ongoing results for the poll "${channelDocument.poll.title}"`,
 				description: `Use \`${msg.guild.commandPrefix}poll <no. of option>\` here or PM me \`poll ${msg.guild.name} | #${msg.channel.name}\` to vote. 🗳\n\n{description}`,
+			}, {
+				descriptions,
 			});
 			await menu.init();
 		}

--- a/Commands/Public/reddit.js
+++ b/Commands/Public/reddit.js
@@ -83,11 +83,15 @@ module.exports = async ({ Constants: { Colors, Text, APIs, EmptySpace } }, { ser
 				},
 			});
 		}
-		new PaginatedEmbed(msg, descriptions, {
+		await new PaginatedEmbed(msg, {
 			color: Colors.RESPONSE,
-			title: `Submission {current description} out of {total descriptions} in r/${subreddit}`,
+			title: `Submission {currentPage} out of {totalPages} in r/${subreddit}`,
 			footer: nsfwFiltered ? `${nsfwFiltered} post${nsfwFiltered > 1 ? "s were" : " was"} filtered for being marked NSFW as this channel is not marked as such.` : "",
-		}, [], fields, thumbnails).init();
+		}, {
+			descriptions,
+			fields,
+			thumbnails,
+		}).init();
 	} else {
 		winston.debug(`Failed to fetch Reddit results`, { svrid: msg.guild.id, chid: msg.channel.id, usrid: msg.author.id, statusCode, err: statusText });
 		msg.send({

--- a/Commands/Public/tag.js
+++ b/Commands/Public/tag.js
@@ -59,14 +59,15 @@ class TagCommand {
 		if (info.length) {
 			for (let i = 0; i < info.length; i++) info[i] = await info[i];
 			const chunks = info.chunk(10);
-			const description = [];
+			const descriptions = [];
 			for (const chunk of chunks) {
-				description.push(chunk.join("\n\n"));
+				descriptions.push(chunk.join("\n\n"));
 			}
-			const menu = new PaginatedEmbed(this.msg, description, {
+			const menu = new PaginatedEmbed(this.msg, {
 				title: `${this.msg.guild}'s tags:`,
 				color: this.Colors.RESPONSE,
-				footer: `Page {current description} out of {total descriptions}`,
+			}, {
+				descriptions,
 			});
 			await menu.init();
 		} else {

--- a/Commands/Public/urban.js
+++ b/Commands/Public/urban.js
@@ -45,11 +45,14 @@ module.exports = async ({ Constants: { Colors, Text, APIs } }, { serverDocument 
 				},
 			]);
 		});
-		const menu = new PaginatedEmbed(msg, descriptions, {
+		const menu = new PaginatedEmbed(msg, {
 			color: Colors.RESPONSE,
-			title: `${!msg.suffix ? "Random d" : "D"}efinition {current description} out of {total descriptions}${msg.suffix ? ` for '${msg.suffix}'` : ""}:`,
+			title: `${!msg.suffix ? "Random d" : "D"}efinition {currentPage} out of {totalPages}${msg.suffix ? ` for '${msg.suffix}'` : ""}:`,
 			footer: body.tags && body.tags.length ? `Tags: ${body.tags.join(", ")}` : "",
-		}, [], fields);
+		}, {
+			descriptions,
+			fields,
+		});
 		await menu.init();
 	} else {
 		winston.debug(`Failed to fetch Urban Dictionary results`, { svrid: msg.guild.id, chid: msg.channel.id, usrid: msg.author.id, statusCode, err: statusText });

--- a/Modules/MessageUtils/PaginatedEmbed.js
+++ b/Modules/MessageUtils/PaginatedEmbed.js
@@ -45,7 +45,7 @@ class PaginatedEmbed {
 		}, embedTemplate);
 
 		this.currentPage = 0;
-		this.totalPages = pageData.pageCount || this.descriptions.length - 1;
+		this.totalPages = pageData.pageCount || this.descriptions.length;
 	}
 
 	async init (timeout = 300000) {
@@ -89,16 +89,16 @@ class PaginatedEmbed {
 	async _handlePageChange (reaction) {
 		switch (reaction.emoji.name) {
 			case this.pageEmojis.back: {
-				this.currentPage--;
-				if (this.currentPage < 0) this.currentPage = 0;
 				this._removeUserReaction(reaction, this.authorID);
+				if (this.currentPage === 0) return;
+				this.currentPage--;
 				this._updateMessage();
 				break;
 			}
 			case this.pageEmojis.forward: {
-				this.currentPage++;
-				if (this.currentPage > this.totalPages) this.currentPage = this.totalPages;
 				this._removeUserReaction(reaction, this.authorID);
+				if (this.currentPage === this.totalPages - 1) return;
+				this.currentPage++;
 				this._updateMessage();
 				break;
 			}
@@ -150,7 +150,7 @@ class PaginatedEmbed {
 	}
 
 	_getFormatOptions (obj) {
-		return Object.assign({ currentPage: this.currentPage + 1, totalPages: this.totalPages + 1 }, obj);
+		return Object.assign({ currentPage: this.currentPage + 1, totalPages: this.totalPages }, obj);
 	}
 }
 

--- a/Modules/MessageUtils/PaginatedEmbed.js
+++ b/Modules/MessageUtils/PaginatedEmbed.js
@@ -1,75 +1,76 @@
 const { Colors, PageEmojis } = require("../../Internals/Constants");
 
 class PaginatedEmbed {
-	constructor (msg, descriptions = [], embed = null, images = [], fields = [], thumbnails = []) {
-		this.client = msg.client;
-		this.originalMsg = msg;
-
+	/**
+	 * After creating a PaginatedEmbed call `#init()` to set it up and start listenig for reactions.
+	 *
+	 * @param originalMsg 	The original message that created this paginated embed.
+	 * 						May be a custom object, the only required fields are `channel` and `author.id`
+	 * @param embedTemplate A slightly edited embed object that serves as the base template for all pages,
+	 * 						with strings being formatted via templates
+	 * @param pageData		All the data used for the different pages of the embed pages,
+	 * 						with the fields being arrays with values (or null) for every page
+	 */
+	constructor (originalMsg, embedTemplate, pageData) {
+		this.channel = originalMsg.channel;
+		this.authorID = originalMsg.author.id;
 		this.pageEmojis = PageEmojis;
 		this.pageEmojiArray = [...Object.values(this.pageEmojis)];
 
-		this.descriptions = descriptions;
-		this.currentDescription = 0;
-		this.totalDescriptions = this.descriptions.length - 1;
+		this.authors = pageData.authors || [];
+		this.titles = pageData.titles || [];
+		this.colors = pageData.colors || [];
+		this.urls = pageData.urls || [];
+		this.descriptions = pageData.descriptions || [];
+		this.fields = pageData.fields || [];
+		this.timestamps = pageData.timestamps || [];
+		this.thumbnails = pageData.thumbnails || [];
+		this.images = pageData.images || [];
+		this.footers = pageData.footers || [];
 
 		this.embedTemplate = Object.assign({
-			title: ``,
+			author: "{author}",
+			authorIcon: null,
+			authorUrl: null,
+			title: "{title}",
 			color: Colors.INFO,
-			description: `{description}`,
-			footer: `Embed {current description} out of {total descriptions} embeds`,
-		}, embed);
-		this.images = images;
-		this.fields = fields;
-		this.thumbnails = thumbnails;
+			url: null,
+			description: "{description}",
+			fields: null,
+			timestamp: null,
+			thumbnail: null,
+			image: null,
+			footer: "{footer}Page {currentPage} out of {totalPages}",
+			footerIcon: null,
+		}, embedTemplate);
+
+		this.currentPage = 0;
+		this.totalPages = pageData.pageCount || this.descriptions.length - 1;
 	}
 
 	async init (timeout = 300000) {
-		await this.sendInitialMessage();
-		if (this.descriptions.length !== 1) {
+		await this._sendInitialMessage();
+		if (this.totalPages > 1) {
 			this.collector = this.msg.createReactionCollector(
-				(reaction, user) => user.id === this.originalMsg.author.id && this.pageEmojiArray.includes(reaction.emoji.name),
+				(reaction, user) => user.id === this.authorID && this.pageEmojiArray.includes(reaction.emoji.name),
 				{ time: timeout }
 			);
-			await this.prepareReactions();
-			this.handle();
+			await this._prepareReactions();
+			this._startCollector();
 		}
 	}
 
-	async sendInitialMessage () {
-		this.msg = await this.originalMsg.channel.send({
-			embed: {
-				color: this.embedTemplate.color,
-				author: this.embedTemplate.author || {},
-				title: this.embedTemplate.title.format({ "current description": this.currentDescription + 1, "total descriptions": this.totalDescriptions + 1 }),
-				description: this.embedTemplate.description.format({ description: this._currentPage }),
-				footer: {
-					text: this.embedTemplate.footer.format({ "current description": this.currentDescription + 1, "total descriptions": this.totalDescriptions + 1 }),
-				},
-				thumbnail: {
-					url: this.thumbnails[this.currentDescription] || null,
-				},
-				image: {
-					url: this.images[this.currentDescription] || null,
-				},
-				fields: this.fields[this.currentDescription] || [],
-			},
-		});
-	}
-
-	get _currentPage () {
-		return this.descriptions[this.currentDescription];
-	}
-
-	async prepareReactions () {
+	async _prepareReactions () {
 		await this.msg.react(this.pageEmojis.back);
 		await this.msg.react(this.pageEmojis.stop);
 		await this.msg.react(this.pageEmojis.forward);
 	}
 
-	async handle () {
+	async _startCollector () {
+		const pageChangeEmojis = [this.pageEmojis.back, this.pageEmojis.forward];
 		this.collector.on("collect", reaction => {
 			if (reaction.emoji.name === this.pageEmojis.stop) return this.collector.stop();
-			if (["◀", "▶"].includes(reaction.emoji.name)) return this._handlePageChange(reaction);
+			if (pageChangeEmojis.includes(reaction.emoji.name)) return this._handlePageChange(reaction);
 		});
 
 		this.collector.once("end", this._handleStop.bind(this));
@@ -82,30 +83,29 @@ class PaginatedEmbed {
 			winston.verbose(`Failed to clear all reactions for paginated menu, will remove only the bots reaction!`, { err: err.name });
 			this.msg.reactions.forEach(r => r.users.remove());
 		}
-		// Null out the collector
 		this.collector = null;
 	}
 
 	async _handlePageChange (reaction) {
 		switch (reaction.emoji.name) {
-			case "◀": {
-				this.currentDescription--;
-				if (this.currentDescription <= 0) this.currentDescription = 0;
-				this.removeUserReaction(reaction, this.originalMsg.author.id);
-				this._update();
+			case this.pageEmojis.back: {
+				this.currentPage--;
+				if (this.currentPage < 0) this.currentPage = 0;
+				this._removeUserReaction(reaction, this.authorID);
+				this._updateMessage();
 				break;
 			}
-			case "▶": {
-				this.currentDescription++;
-				if (this.currentDescription >= this.totalDescriptions) this.currentDescription = this.totalDescriptions;
-				this.removeUserReaction(reaction, this.originalMsg.author.id);
-				this._update();
+			case this.pageEmojis.forward: {
+				this.currentPage++;
+				if (this.currentPage > this.totalPages) this.currentPage = this.totalPages;
+				this._removeUserReaction(reaction, this.authorID);
+				this._updateMessage();
 				break;
 			}
 		}
 	}
 
-	async removeUserReaction (reaction, user) {
+	async _removeUserReaction (reaction, user) {
 		try {
 			await reaction.users.remove(user);
 		} catch (err) {
@@ -113,25 +113,44 @@ class PaginatedEmbed {
 		}
 	}
 
-	async _update () {
-		this.msg = await this.msg.edit({
+	get _currentMessageContent () {
+		return {
 			embed: {
-				color: this.embedTemplate.color,
-				author: this.embedTemplate.author || {},
-				title: this.embedTemplate.title.format({ "current description": this.currentDescription + 1, "total descriptions": this.totalDescriptions + 1 }),
-				description: this.embedTemplate.description.format({ description: this._currentPage }),
-				footer: {
-					text: this.embedTemplate.footer.format({ "current description": this.currentDescription + 1, "total descriptions": this.totalDescriptions + 1 }),
+				author: {
+					name: this.embedTemplate.author.format(this._getFormatOptions({ author: this.authors[this.currentPage] })),
+					icon_url: this.embedTemplate.authorIcon,
+					url: this.embedTemplate.authorUrl,
 				},
+				title: this.embedTemplate.title.format(this._getFormatOptions({ title: this.titles[this.currentPage] })),
+				color: this.colors[this.currentPage] || this.embedTemplate.color,
+				url: this.urls[this.currentPage] || this.embedTemplate.url,
+				description: this.embedTemplate.description.format(this._getFormatOptions({ description: this.descriptions[this.currentPage] })),
+				fields: this.fields[this.currentPage] || this.embedTemplate.fields,
+				timestamp: this.timestamps[this.currentPage] || this.embedTemplate.timestamp,
 				thumbnail: {
-					url: this.thumbnails[this.currentDescription] || null,
+					url: this.thumbnails[this.currentPage] || this.embedTemplate.thumbnail,
 				},
 				image: {
-					url: this.images[this.currentDescription] || null,
+					url: this.images[this.currentPage] || this.embedTemplate.image,
 				},
-				fields: this.fields[this.currentDescription] || [],
+				footer: {
+					text: this.embedTemplate.footer.format(this._getFormatOptions({ footer: this.footers[this.currentPage] })),
+					icon_url: this.embedTemplate.footerIcon,
+				},
 			},
-		});
+		};
+	}
+
+	async _sendInitialMessage () {
+		this.msg = await this.channel.send(this._currentMessageContent);
+	}
+
+	async _updateMessage () {
+		this.msg = await this.msg.edit(this._currentMessageContent);
+	}
+
+	_getFormatOptions (obj) {
+		return Object.assign({ currentPage: this.currentPage + 1, totalPages: this.totalPages + 1 }, obj);
 	}
 }
 

--- a/Modules/MessageUtils/PaginatedEmbed.js
+++ b/Modules/MessageUtils/PaginatedEmbed.js
@@ -2,31 +2,43 @@ const { Colors, PageEmojis } = require("../../Internals/Constants");
 
 class PaginatedEmbed {
 	/**
-	 * After creating a PaginatedEmbed call `#init()` to set it up and start listenig for reactions.
+	 * After creating a PaginatedEmbed call `#init()` to set it up and start listening for reactions.
 	 *
-	 * @param originalMsg 	The original message that created this paginated embed.
+	 * @param {Message} originalMsg 	The original message that created this paginated embed.
 	 * 						May be a custom object, the only required fields are `channel` and `author.id`
 	 * @param embedTemplate A slightly edited embed object that serves as the base template for all pages,
 	 * 						with strings being formatted via templates
 	 * @param pageData		All the data used for the different pages of the embed pages,
 	 * 						with the fields being arrays with values (or null) for every page
 	 */
-	constructor (originalMsg, embedTemplate, pageData) {
+	constructor (originalMsg, embedTemplate, {
+		authors = [],
+		titles = [],
+		colors = [],
+		urls = [],
+		descriptions = [],
+		fields = [],
+		timestamps = [],
+		thumbnails = [],
+		images = [],
+		footers = [],
+		pageCount = null,
+	} = {}) {
 		this.channel = originalMsg.channel;
 		this.authorID = originalMsg.author.id;
 		this.pageEmojis = PageEmojis;
 		this.pageEmojiArray = [...Object.values(this.pageEmojis)];
 
-		this.authors = pageData.authors || [];
-		this.titles = pageData.titles || [];
-		this.colors = pageData.colors || [];
-		this.urls = pageData.urls || [];
-		this.descriptions = pageData.descriptions || [];
-		this.fields = pageData.fields || [];
-		this.timestamps = pageData.timestamps || [];
-		this.thumbnails = pageData.thumbnails || [];
-		this.images = pageData.images || [];
-		this.footers = pageData.footers || [];
+		this.authors = authors;
+		this.titles = titles;
+		this.colors = colors;
+		this.urls = urls;
+		this.descriptions = descriptions;
+		this.fields = fields;
+		this.timestamps = timestamps;
+		this.thumbnails = thumbnails;
+		this.images = images;
+		this.footers = footers;
 
 		this.embedTemplate = Object.assign({
 			author: "{author}",
@@ -45,7 +57,7 @@ class PaginatedEmbed {
 		}, embedTemplate);
 
 		this.currentPage = 0;
-		this.totalPages = pageData.pageCount || this.descriptions.length;
+		this.totalPages = pageCount || this.descriptions.length;
 	}
 
 	async init (timeout = 300000) {

--- a/Modules/MessageUtils/PaginatedEmbed.js
+++ b/Modules/MessageUtils/PaginatedEmbed.js
@@ -117,14 +117,14 @@ class PaginatedEmbed {
 		return {
 			embed: {
 				author: {
-					name: this.embedTemplate.author.format(this._getFormatOptions({ author: this.authors[this.currentPage] })),
+					name: this.embedTemplate.author.format(this._getFormatOptions({ author: this.authors[this.currentPage] || "" })),
 					icon_url: this.embedTemplate.authorIcon,
 					url: this.embedTemplate.authorUrl,
 				},
-				title: this.embedTemplate.title.format(this._getFormatOptions({ title: this.titles[this.currentPage] })),
+				title: this.embedTemplate.title.format(this._getFormatOptions({ title: this.titles[this.currentPage] || "" })),
 				color: this.colors[this.currentPage] || this.embedTemplate.color,
 				url: this.urls[this.currentPage] || this.embedTemplate.url,
-				description: this.embedTemplate.description.format(this._getFormatOptions({ description: this.descriptions[this.currentPage] })),
+				description: this.embedTemplate.description.format(this._getFormatOptions({ description: this.descriptions[this.currentPage] || "" })),
 				fields: this.fields[this.currentPage] || this.embedTemplate.fields,
 				timestamp: this.timestamps[this.currentPage] || this.embedTemplate.timestamp,
 				thumbnail: {
@@ -134,7 +134,7 @@ class PaginatedEmbed {
 					url: this.images[this.currentPage] || this.embedTemplate.image,
 				},
 				footer: {
-					text: this.embedTemplate.footer.format(this._getFormatOptions({ footer: this.footers[this.currentPage] })),
+					text: this.embedTemplate.footer.format(this._getFormatOptions({ footer: this.footers[this.currentPage] || "" })),
 					icon_url: this.embedTemplate.footerIcon,
 				},
 			},

--- a/Modules/Polls.js
+++ b/Modules/Polls.js
@@ -16,20 +16,22 @@ module.exports = {
 				`\t**${option}**`,
 			].join("\n"));
 			map = map.chunk(10);
-			const description = [];
+			const descriptions = [];
 			for (const innerArray of map) {
-				description.push(innerArray.join("\n"));
+				descriptions.push(innerArray.join("\n"));
 			}
 			const menu = new PaginatedEmbed({
 				channel: ch,
 				author: {
 					id: usr.id,
 				},
-			}, description, {
+			}, {
 				title: `🍻 A poll named "__${title}__" has started!`,
 				color: Colors.INFO,
 				description: `${usr} has started a poll in here! Run \`${svr.commandPrefix}poll\` to see all available choices!\nThe following options are available:\n\n{description}`,
 				footer: `Use "${svr.commandPrefix}poll <option no.>" here or PM me "poll ${svr}|#${ch.name}" to vote.`,
+			}, {
+				descriptions,
 			});
 			await menu.init();
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The PaginatedEmbed now supports pagination of almost every value of an embed (exceptions are the author icon/url and footer icon). Values are now passed inside an object to the constructor so only fields which are actually needed have to be passed (to avoid `null, null, null, ["finally"]` in the constructor). Old commands have been updated to support this new format.

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [x] This PR modifies commands
  - [x] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
