### PR TITLE
Fix updater module when updater website redirects indefinitely

### DIFF
--- a/Commands/Shared/debug.js
+++ b/Commands/Shared/debug.js
@@ -1,5 +1,4 @@
 const Updater = require("../../Modules/Updater");
-const auth = require("../../Configurations/auth");
 const os = require("os");
 
 module.exports = async ({ client, Constants: { Colors, Perms } }, msg, commandData) => {

--- a/Modules/Updater.js
+++ b/Modules/Updater.js
@@ -8,13 +8,13 @@ module.exports = {
 	check: async (config = configJSON) => {
 		let res;
 		try {
-			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${config.branch}/check?v=${config.version}`);
+			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${config.branch}/check?v=${config.version}`, { redirect: false });
 		} catch (err) {
 			winston.warn(`Failed to check for new updates. ~.~\n`, err);
 			throw err;
 		}
 		if (res) {
-			if (!res.body["up-to-date"] && !res.body.latest) {
+			if (res.statusCode !== 200 || (!res.body["up-to-date"] && !res.body.latest)) {
 				return 404;
 			}
 			return res.body;
@@ -23,13 +23,13 @@ module.exports = {
 	get: async (branch, version) => {
 		let res;
 		try {
-			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${branch}/${version}`);
+			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${branch}/${version}`, { redirect: false });
 		} catch (err) {
 			res = {};
 			res.statusCode = 404;
 		}
 		if (res) {
-			if (res.statusCode === 404) {
+			if (res.statusCode !== 200) {
 				return 404;
 			}
 			return res.body;
@@ -47,7 +47,10 @@ module.exports = {
 
 		let res;
 		try {
-			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${config.branch}/check?v=${config.version}`);
+			res = await snekfetch.get(`https://status.gawesomebot.com/api/versions/${config.branch}/check?v=${config.version}`, { redirect: false });
+			if (res.statusCode !== 200) {
+				throw new Error(`Updater received unexpected status code ${res.statusCode} ${res.statusText}`);
+			}
 		} catch (err) {
 			winston.error("An error occurred while fetching version metadata ~.~\n", err);
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Right now ~~Gilbert broke the updater and refuses to fix it~~ which breaks the bot.
This PR firstly disables redirects in Snekfetch to avoid it getting stuck in an infinite redirect loop (Snekfetch doesn't count the redirects and just keeps going until it crashes in the future due to an OOM or Stack Overflow or whatever can happen in JS). Now, this would break the updater if it would actually properly redirect sonewhere but Snekfetch would need to implement a redirect counter first for a proper implementation.
Secondly this PR checks if the response code is 200 - if not it returns the usual 404 internally. This is because Snekfetch would return the 301 response otherwise which would confuse the poor bot even more.

These changes fix:
- Bot startup which would get stuck while checking for updates
- The debug command which fetches the version info
- The maintainer dashboard which does the same

This also superseds (is that a word) #364 since this PR fixes more than just the function that is checked on startup.

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
