### PR TITLE
Make shardTotal message fit to other messages

### DIFF
--- a/master.js
+++ b/master.js
@@ -83,7 +83,7 @@ Boot({ configJS, configJSON, auth }, scope).then(() => {
 
 			winston.silly("Confirming shardTotal config value.");
 			if (!parseInt(configJS.shardTotal) && configJS.shardTotal !== "auto") {
-				winston.error(`In config.js, shardTotal must be a number or "auto"`);
+				winston.error(`You must enter your shardTotal config value as a valid number, or "auto".`);
 				process.exit(1);
 			}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the shardTotal message to when it isn't a number or auto.
This PR isn't important at all, but it makes everything fit more nicely in place.

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes command functions
  - [ ] This PR changes metadata for the command, updated in `commands.js`
  - [ ] This PR removes and/or adds commands
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (endpoint functions)
  - [ ] This PR modifies paths to existing resources
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
