### PR TITLE
Fix formatting character escaping in urban command

### DIFF
--- a/Commands/Public/urban.js
+++ b/Commands/Public/urban.js
@@ -19,9 +19,8 @@ module.exports = async ({ Constants: { Colors, Text, APIs } }, documents, msg, c
 		const descriptions = [];
 		const fields = [];
 		body.list.forEach(d => {
-			const description = `${!msg.suffix ? `**${d.word}**:\n\n` : ""}${d.definition}`;
-			let merged = `${description}${d.example ? `\n\n_${d.example}_` : ""}`
-				.replace(/_\*~/g, "\\$&")
+			const description = `${!msg.suffix ? `**${d.word}**:\n\n` : ""}${d.definition.replace(/[_*~]/g, "\\$&")}`;
+			let merged = `${description}${d.example ? `\n\n_${d.example.replace(/[_*~]/g, "\\$&")}_` : ""}`
 				.replace(/\[.+?\]/g, m => `${m}(http://urbandictionary.com/define.php?term=${encodeURIComponent(m.slice(1, -1))})`);
 			if (merged.length > 2048) {
 				merged = `${merged.substring(0, 2044)}_...`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously only `_*~` would be escaped, in that specific combination. And if I put [] around it it would've also escaped the formatting that is specifically added right before. Whoops.

It's nothing breaking since the regex did literally nothing before, some urban entries would have messed with the formatting though.

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [x] This PR modifies commands
  - [ ] This PR changes metadata for commands (such as usage), updated in `commands.js`
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (controllers & middleware)
  - [ ] This PR modifies paths to existing resources (routes)
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
