### PR TITLE
:sparkles: Streamers command + eval command enhances

### DIFF
--- a/Commands/Public/streamers.js
+++ b/Commands/Public/streamers.js
@@ -1,0 +1,53 @@
+const PaginatedEmbed = require("../../Modules/MessageUtils/PaginatedEmbed");
+const isStreaming = require("../../Modules/Utils/StreamerUtils");
+
+module.exports = async ({ Constants: { Colors, Text }, client }, { serverDocument }, msg, commandData) => {
+	if (serverDocument.config.streamers_data.length) {
+		const descriptions = [];
+		const thumbnails = [];
+		const titles = [];
+		const footers = [];
+		const colors = [];
+		await Promise.all(serverDocument.config.streamers_data.map(async streamer => {
+			const streamerData = await isStreaming(streamer.type, streamer._id);
+			if (!streamerData) return;
+			descriptions.push(`**${streamerData.name}** is streaming **${streamerData.game}**, [watch their stream now](${streamerData.url})!`);
+			thumbnails.push(streamerData.preview);
+			titles.push(`${streamerData.name} is live!`);
+			footers.push(`${streamerData.type} Streamer • `);
+			colors.push(streamerData.type === "YouTube" ? Colors.YOUTUBE : Colors.TWITCH);
+		}));
+		if (descriptions.length) {
+			await new PaginatedEmbed(msg, {
+				footer: "{footer}Streamer {currentPage} out of {totalPages}",
+			}, {
+				descriptions,
+				thumbnails,
+				titles,
+				footers,
+				colors,
+			}).init();
+		} else if (serverDocument.config.streamers_data.length === 1) {
+			msg.send({
+				embed: {
+					color: Colors.SOFT_ERR,
+					description: "The 1 streamer added to this server isn't live right now. 😞",
+				},
+			});
+		} else {
+			msg.send({
+				embed: {
+					color: Colors.SOFT_ERR,
+					description: `None of the ${serverDocument.config.streamers_data.length} streamers added to this server are live right now. 😞`,
+				},
+			});
+		}
+	} else {
+		msg.send({
+			embed: {
+				color: Colors.SOFT_ERR,
+				description: "I'm currently not tracking any streamers. A Server Admin can add a streamer to track in the dashboard! 🌐",
+			},
+		});
+	}
+};

--- a/Commands/Public/streamers.js
+++ b/Commands/Public/streamers.js
@@ -46,7 +46,7 @@ module.exports = async ({ Constants: { Colors, Text }, client }, { serverDocumen
 		msg.send({
 			embed: {
 				color: Colors.SOFT_ERR,
-				description: "I'm currently not tracking any streamers. A Server Admin can add a streamer to track in the dashboard! 🌐",
+				description: "I'm not tracking any streamers yet!\nA Server Admin can add a streamer to track on the dashboard! 🌐",
 			},
 		});
 	}

--- a/Commands/Shared/eval.js
+++ b/Commands/Shared/eval.js
@@ -3,13 +3,17 @@ const { Gist, RegExpMaker } = require("../../Modules/Utils/");
 module.exports = async (main, msg, commandData) => {
 	if (msg.suffix) {
 		const hrstart = process.hrtime();
+		const forceUnsafe = msg.suffix.split(" ")[0] === "--unsafe";
 		let { suffix } = msg;
+		if (forceUnsafe) suffix = suffix.split(" ").splice(1).join(" ");
 		try {
 			if (suffix.startsWith("```js") && suffix.endsWith("```")) suffix = suffix.substring(5, suffix.length - 3);
 			const asyncEval = (code, returns) => `(async () => {\n${!returns ? `return ${code.trim()}` : `${code.trim()}`}\n})()`;
-			suffix = suffix
-				.replace(/(main\.bot\.token|main\.client\.token|msg\.client\.token)/g, "\"mfaNop\"")
-				.replace(/\.(clientToken|clientSecret|discordList|discordBots|discordBotsOrg|giphyAPI|googleCSEID|googleAPI|imgurClientID|microsoftTranslation|twitchClientID|wolframAppID|openExchangeRatesKey|omdbAPI|gistKey)/g, "mfaNop");
+			if (!forceUnsafe) {
+				suffix = suffix
+					.replace(/(main\.bot\.token|main\.client\.token|msg\.client\.token)/g, "\"mfaNop\"")
+					.replace(/\.(clientToken|clientSecret|discordList|discordBots|discordBotsOrg|giphyAPI|googleCSEID|googleAPI|imgurClientID|microsoftTranslation|twitchClientID|wolframAppID|openExchangeRatesKey|omdbAPI|gistKey)/g, "mfaNop");
+			}
 			const { discord, tokens } = require("../../Configurations/auth");
 			const censor = [
 				discord.clientSecret,

--- a/Commands/Shared/eval.js
+++ b/Commands/Shared/eval.js
@@ -3,7 +3,7 @@ const { Gist, RegExpMaker } = require("../../Modules/Utils/");
 module.exports = async (main, msg, commandData) => {
 	if (msg.suffix) {
 		const hrstart = process.hrtime();
-		const forceUnsafe = msg.suffix.split(" ")[0] === "--unsafe";
+		const forceUnsafe = msg.suffix.split(" ")[0].toLowerCase() === "--unsafe";
 		let { suffix } = msg;
 		if (forceUnsafe) suffix = suffix.split(" ").splice(1).join(" ");
 		try {

--- a/Modules/Utils/StreamChecker.js
+++ b/Modules/Utils/StreamChecker.js
@@ -12,7 +12,7 @@ module.exports = async (client, server, serverDocument, streamerDocument) => {
 			winston.verbose(`Streamer "${streamerDocument._id}" started streaming`, { svrid: server.id });
 			streamerQueryDocument.set("live_state", true);
 
-			const channel = streamerDocument.channel_id ? server.channels.get(streamerDocument.channel_id) : server.defaultChannel;
+			const channel = streamerDocument.channel_id ? server.channels.get(streamerDocument.channel_id) : null;
 			if (channel) {
 				const channelDocument = serverDocument.channels[channel.id];
 				if (!channelDocument || channelDocument.bot_enabled) {


### PR DESCRIPTION
* :sparkles: Port streamers command over from V4
* :sparkles: If the eval command is executed with the --unsafe argument, tokens will be accessible by the eval function. Tokens are always filtered in the final message sent to Discord, this argument does not affect that behavior.
* :bug: Do not send streamer alerts if no channel is configured

**Please describe the changes this PR makes and why it should be merged:**

**What does this PR do:**
- [ ] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [x] This PR modifies commands
  - [ ] This PR changes metadata for commands (such as usage), updated in `commands.js`
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (controllers & middleware)
  - [ ] This PR modifies paths to existing resources (routes)
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
