### PR TITLE
Add message content support to PaginatedEmbed

### DIFF
--- a/Modules/MessageUtils/PaginatedEmbed.js
+++ b/Modules/MessageUtils/PaginatedEmbed.js
@@ -12,6 +12,7 @@ class PaginatedEmbed {
 	 * 						with the fields being arrays with values (or null) for every page
 	 */
 	constructor (originalMsg, embedTemplate, {
+		contents = [],
 		authors = [],
 		titles = [],
 		colors = [],
@@ -29,6 +30,7 @@ class PaginatedEmbed {
 		this.pageEmojis = PageEmojis;
 		this.pageEmojiArray = [...Object.values(this.pageEmojis)];
 
+		this.contents = contents;
 		this.authors = authors;
 		this.titles = titles;
 		this.colors = colors;
@@ -40,7 +42,8 @@ class PaginatedEmbed {
 		this.images = images;
 		this.footers = footers;
 
-		this.embedTemplate = Object.assign({
+		this.messageTemplate = Object.assign({
+			content: "{content}",
 			author: "{author}",
 			authorIcon: null,
 			authorUrl: null,
@@ -127,27 +130,28 @@ class PaginatedEmbed {
 
 	get _currentMessageContent () {
 		return {
+			content: this.messageTemplate.content.format(this._getFormatOptions({ content: this.contents[this.currentPage] || "" })),
 			embed: {
 				author: {
-					name: this.embedTemplate.author.format(this._getFormatOptions({ author: this.authors[this.currentPage] || "" })),
-					icon_url: this.embedTemplate.authorIcon,
-					url: this.embedTemplate.authorUrl,
+					name: this.messageTemplate.author.format(this._getFormatOptions({ author: this.authors[this.currentPage] || "" })),
+					icon_url: this.messageTemplate.authorIcon,
+					url: this.messageTemplate.authorUrl,
 				},
-				title: this.embedTemplate.title.format(this._getFormatOptions({ title: this.titles[this.currentPage] || "" })),
-				color: this.colors[this.currentPage] || this.embedTemplate.color,
-				url: this.urls[this.currentPage] || this.embedTemplate.url,
-				description: this.embedTemplate.description.format(this._getFormatOptions({ description: this.descriptions[this.currentPage] || "" })),
-				fields: this.fields[this.currentPage] || this.embedTemplate.fields,
-				timestamp: this.timestamps[this.currentPage] || this.embedTemplate.timestamp,
+				title: this.messageTemplate.title.format(this._getFormatOptions({ title: this.titles[this.currentPage] || "" })),
+				color: this.colors[this.currentPage] || this.messageTemplate.color,
+				url: this.urls[this.currentPage] || this.messageTemplate.url,
+				description: this.messageTemplate.description.format(this._getFormatOptions({ description: this.descriptions[this.currentPage] || "" })),
+				fields: this.fields[this.currentPage] || this.messageTemplate.fields,
+				timestamp: this.timestamps[this.currentPage] || this.messageTemplate.timestamp,
 				thumbnail: {
-					url: this.thumbnails[this.currentPage] || this.embedTemplate.thumbnail,
+					url: this.thumbnails[this.currentPage] || this.messageTemplate.thumbnail,
 				},
 				image: {
-					url: this.images[this.currentPage] || this.embedTemplate.image,
+					url: this.images[this.currentPage] || this.messageTemplate.image,
 				},
 				footer: {
-					text: this.embedTemplate.footer.format(this._getFormatOptions({ footer: this.footers[this.currentPage] || "" })),
-					icon_url: this.embedTemplate.footerIcon,
+					text: this.messageTemplate.footer.format(this._getFormatOptions({ footer: this.footers[this.currentPage] || "" })),
+					icon_url: this.messageTemplate.footerIcon,
 				},
 			},
 		};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously it wasn't possible to paginate the bog-standard message content via a PaginatedEmbed, only actual embed fields.
And rename embedTemplate to messageTemplate as it's not strictly holding embed data anymore. Though the name PaginatedEmbed itself is also incorrect now but who cares.

**What does this PR do:**
- [x] This PR changes internal functions, modules and/or utilities
  - [ ] This PR modifies the Extension API
- [ ] This PR modifies commands
  - [ ] This PR changes metadata for commands (such as usage), updated in `commands.js`
- [ ] This PR modifies Web processing and/or content
  - [ ] This PR modifies static/ejs content
  - [ ] This PR modifies request processing (controllers & middleware)
  - [ ] This PR modifies paths to existing resources (routes)
- [ ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
