### PR TITLE
Fixed TypeError

### DIFF
--- a/Commands/Shared/eval.js
+++ b/Commands/Shared/eval.js
@@ -65,7 +65,7 @@ module.exports = async (main, msg, commandData) => {
 			msg.send({
 				embed: {
 					color: 0xFF0000,
-					description: `\`\`\`js\n${err.stack}\`\`\``,
+					description: `\`\`\`js\n${err ? err.stack : err}\`\`\``,
 					footer: {
 						text: `Execution time: ${process.hrtime(hrstart)[0]}s ${Math.floor(process.hrtime(hrstart)[1] / 1000000)}ms`,
 					},


### PR DESCRIPTION
Basically, I found that if you cause/execute an error that is undefined/null, when the bot tries to send err.stack, it will result in a TypeError because err is undefined, and so it can't read the stack property. This is a very simple fix.

You can replicate this error yourself by just trying to execute Promise.reject().

**Please describe the changes this PR makes and why it should be merged:**

**What does this PR do:**
- [ x] This PR changes internal functions, modules and/or utilities
  - [x ] This PR modifies the Extension API
- [y ] This PR modifies commands
  - [x ] This PR changes metadata for commands (such as usage), updated in `commands.js`
- [x ] This PR modifies Web processing and/or content
  - [x ] This PR modifies static/ejs content
  - [ x] This PR modifies request processing (controllers & middleware)
  - [ x] This PR modifies paths to existing resources (routes)
- [x ] This PR **only** includes non-code changes, like changes to default configurations, README, typos, etc.
